### PR TITLE
fix: pricing plan naming

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: Run on PRs
 
 on:
   pull_request:
-    types: [opened, closed]
+    types: [opened, closed, synchronize]
 
 jobs:
   build:
@@ -26,7 +26,7 @@ jobs:
         run: pnpm i
 
       - name: Run build for non-merged PR
-        if: github.event.action == 'closed' && github.event.pull_request.merged != true
+        if: github.event.action != 'closed' && github.event.pull_request.merged != true
         id: build_non_merge
         env:
           ZE_SECRET_TOKEN: ${{ secrets.ZEPHYR_AUTH_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,3 +48,11 @@ jobs:
         env:
           ZE_SECRET_TOKEN: ${{ secrets.ZEPHYR_AUTH_TOKEN }}
         run: pnpm run build
+
+      - name: Zephyr deploy summary
+        uses: ZephyrCloudIO/deploy-summary-action@v1.3.0
+        id: zephyr-summary
+        with:
+          application_uid: zephyr-landing.zephyr-website.zephyrcloudio
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_environment: Zephyr Landing Page (Preview)

--- a/src/components/sections/pricing/index.tsx
+++ b/src/components/sections/pricing/index.tsx
@@ -12,7 +12,7 @@ interface PricingTier {
 
 const pricingTiers: PricingTier[] = [
   {
-    name: 'Free',
+    name: 'Personal',
     price: '$0',
     link: 'https://app.zephyr-cloud.io/',
     features: [
@@ -24,12 +24,12 @@ const pricingTiers: PricingTier[] = [
     ],
   },
   {
-    name: 'Standard',
+    name: 'Business',
     price: '$99',
     link: 'https://app.zephyr-cloud.io/',
     isHighlighted: true,
     features: [
-      'Includes all Free features',
+      'Includes all Personal plan features',
       'Starts after the first user',
       'Free for view only access',
       'Free for billing and account admins only accounts',

--- a/src/components/sections/pricing/pricing-card.tsx
+++ b/src/components/sections/pricing/pricing-card.tsx
@@ -27,7 +27,7 @@ export const PricingCard: React.FC<PricingCardProps> = ({
             }
       }
     >
-      <div className="text-center h-[160px]">
+      <div className="text-center pb-5">
         <h3 className="text-xl mb-4">{name}</h3>
         <div className="text-5xl font-bold tracking-wider">
           <span className="bg-gradient-to-r from-[#2a2a2a] via-white to-[#2a2a2a] text-transparent bg-clip-text">

--- a/src/components/sections/pricing/pricing-table.tsx
+++ b/src/components/sections/pricing/pricing-table.tsx
@@ -15,7 +15,7 @@ const PricingTable: React.FC = () => {
               Personal
             </th>
             <th className="p-4 text-left text-lg font-normal text-gray-200">
-              Pro
+              Business
             </th>
             <th className="p-4 text-left text-lg font-normal text-gray-200">
               Enterprise


### PR DESCRIPTION
## What's added in this PR?

Changes to Pricing names:
- Free -> Personal
- Standard -> Business
- Enterprise -> Enterprise

### Before:

![image](https://github.com/user-attachments/assets/3c9ca2b0-2ef4-4495-84cc-1150a0a5461e)

### After:

![image](https://github.com/user-attachments/assets/f313f543-9e32-4013-8643-4c815e09edcf)




## What's the issue related to this PR?

Better reflect users under their plans.

## How to test this PR?

See reflected changes on preview environment.

## Checklist

- [x] I have added explaination of the changes I made
- [x] UI related: this PR has been visually reviewed for both web, mobile and tablet
