### PR TITLE
feat: add intercom chat

### DIFF
--- a/config/public/sitemap.xml
+++ b/config/public/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://zephyr-cloud.io/</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/blog</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/contact</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/discord</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/enterprise</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/github</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/linkedin</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/pricing</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/privacy</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/twitter</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/youtube</loc>
-    <lastmod>2025-05-20</lastmod>
+    <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/config/public/sitemap.xml
+++ b/config/public/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://zephyr-cloud.io/</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/blog</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/contact</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/discord</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/enterprise</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/github</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/linkedin</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/pricing</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/privacy</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/twitter</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://zephyr-cloud.io/youtube</loc>
-    <lastmod>2025-04-25</lastmod>
+    <lastmod>2025-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/modern.config.ts
+++ b/modern.config.ts
@@ -25,6 +25,11 @@ export default defineConfig({
   },
   source: {
     mainEntryName: 'index',
+    define: {
+      'process.env.PUBLIC_RSPRESS_INTERCOM_APP_ID': JSON.stringify(
+        process.env.PUBLIC_RSPRESS_INTERCOM_APP_ID,
+      ),
+    },
   },
   server: {
     port: 3000,

--- a/modern.config.ts
+++ b/modern.config.ts
@@ -26,8 +26,8 @@ export default defineConfig({
   source: {
     mainEntryName: 'index',
     define: {
-      'process.env.PUBLIC_RSPRESS_INTERCOM_APP_ID': JSON.stringify(
-        process.env.PUBLIC_RSPRESS_INTERCOM_APP_ID,
+      '__INTERCOM_APP_ID__': JSON.stringify(
+        process.env.PUBLIC_INTERCOM_APP_ID,
       ),
     },
   },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "rehype-highlight": "^7.0.2",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "zephyr-modernjs-plugin": "0.0.39"
+    "zephyr-modernjs-plugin": "0.0.39",
+    "@intercom/messenger-js-sdk": "^0.0.14"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
@@ -75,9 +76,6 @@
   },
   "packageManager": "pnpm@10.6.3",
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "core-js"
-    ]
+    "onlyBuiltDependencies": ["@swc/core", "core-js"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "pre-commit": "npx lint-staged"
   },
   "dependencies": {
+    "@intercom/messenger-js-sdk": "^0.0.14",
     "@mdx-js/react": "3.1.0",
     "@modern-js/plugin-bff": "^2.67.5",
     "@modern-js/plugin-express": "^2.67.5",
@@ -49,8 +50,7 @@
     "rehype-highlight": "^7.0.2",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "zephyr-modernjs-plugin": "0.0.39",
-    "@intercom/messenger-js-sdk": "^0.0.14"
+    "zephyr-modernjs-plugin": "0.0.39"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
@@ -76,6 +76,9 @@
   },
   "packageManager": "pnpm@10.6.3",
   "pnpm": {
-    "onlyBuiltDependencies": ["@swc/core", "core-js"]
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "core-js"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@intercom/messenger-js-sdk':
+        specifier: ^0.0.14
+        version: 0.0.14
       '@mdx-js/react':
         specifier: 3.1.0
         version: 3.1.0(@types/react@18.3.18)(react@18.3.1)
@@ -1789,6 +1792,9 @@ packages:
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
+
+  '@intercom/messenger-js-sdk@0.0.14':
+    resolution: {integrity: sha512-2dH4BDAh9EI90K7hUkAdZ76W79LM45Sd1OBX7t6Vzy8twpNiQ5X+7sH9G5hlJlkSGnf+vFWlFcy9TOYAyEs1hA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -10108,6 +10114,8 @@ snapshots:
 
   '@fastify/busboy@2.1.1':
     optional: true
+
+  '@intercom/messenger-js-sdk@0.0.14': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/src/components/sections/community/testimonial-card.tsx
+++ b/src/components/sections/community/testimonial-card.tsx
@@ -3,7 +3,8 @@ import {
   LinkedInLogoIcon,
   TwitterLogoIcon,
 } from '@radix-ui/react-icons';
-import React, { memo } from 'react';
+import type React from 'react';
+import { memo } from 'react';
 import TwitchIcon from '../../../images/twitch.svg?react';
 import YoutubeIcon from '../../../images/yt.svg?react';
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+declare const __INTERCOM_APP_ID__: string | undefined;

--- a/src/lib/intercom.ts
+++ b/src/lib/intercom.ts
@@ -1,0 +1,14 @@
+import type { IntercomSettings } from '@intercom/messenger-js-sdk/dist/types';
+
+export const INTERCOM_SETTINGS: Partial<IntercomSettings> = {
+  page_title: 'Zephyr Cloud',
+  action_color: '#eee',
+  vertical_padding: 80,
+  horizontal_padding: 20,
+  background_color: '#eee',
+  custom_launcher_selector: '#intercom-launcher',
+  company: {
+    name: 'Website',
+  },
+  name: 'Zephyr Website User',
+};

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -2,8 +2,20 @@ import { Outlet } from '@modern-js/runtime/router';
 import './index.css';
 import Header from '@/components/header';
 import Footer from '@/components/sections/footer';
+import { INTERCOM_SETTINGS } from '@/lib/intercom';
+import Intercom from '@intercom/messenger-js-sdk';
 
 export default function Layout() {
+  const appId = process.env.PUBLIC_RSPRESS_INTERCOM_APP_ID;
+  if (appId) {
+    Intercom({
+      ...INTERCOM_SETTINGS,
+      app_id: appId,
+      utm_source: 'website',
+    });
+  }
+
+  console.log('layout');
   return (
     <div className=" min-h-screen dark antialiased text-zinc-200 ">
       <div className="mx-auto">

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -6,7 +6,7 @@ import { INTERCOM_SETTINGS } from '@/lib/intercom';
 import Intercom from '@intercom/messenger-js-sdk';
 
 export default function Layout() {
-  const appId = process.env.PUBLIC_RSPRESS_INTERCOM_APP_ID;
+  const appId = process.env.PUBLIC_INTERCOM_APP_ID;
   if (appId) {
     Intercom({
       ...INTERCOM_SETTINGS,

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -4,16 +4,18 @@ import Header from '@/components/header';
 import Footer from '@/components/sections/footer';
 import { INTERCOM_SETTINGS } from '@/lib/intercom';
 import Intercom from '@intercom/messenger-js-sdk';
+import { useEffect } from 'react';
 
 export default function Layout() {
-  const appId = process.env.PUBLIC_INTERCOM_APP_ID;
-  if (appId) {
-    Intercom({
-      ...INTERCOM_SETTINGS,
-      app_id: appId,
-      utm_source: 'website',
-    });
-  }
+  useEffect(() => {
+    if (__INTERCOM_APP_ID__) {
+      Intercom({
+        ...INTERCOM_SETTINGS,
+        app_id: __INTERCOM_APP_ID__,
+        utm_source: 'website',
+      });
+    }
+  }, []);
 
   return (
     <div className=" min-h-screen dark antialiased text-zinc-200 ">

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -15,7 +15,6 @@ export default function Layout() {
     });
   }
 
-  console.log('layout');
   return (
     <div className=" min-h-screen dark antialiased text-zinc-200 ">
       <div className="mx-auto">


### PR DESCRIPTION
## What's added in this PR?

Add a Intercom chat to centralize messages on documentation website to our Intercom channel:

![image](https://github.com/user-attachments/assets/27b36fc5-8955-4a14-862b-5c5877c7751b)
_Intercom chat in documentation page_

![image](https://github.com/user-attachments/assets/7cde263e-242d-4228-8f0f-47243a5968df)
_Message arrived in Intercom channel_

![Screenshot from 2025-05-20 11-12-31](https://github.com/user-attachments/assets/c16fa7c0-9713-44ab-ba44-774ae641e3eb)
_Intercom chat configuration panel_

## What's the issue related to this PR?

To run we need to create a new centralize APP in the Intercom and apply the APP ID as a environment variable in this repo root:
![image](https://github.com/user-attachments/assets/5f965cd3-0efe-42e1-91dd-0e4ac509e28e)
_env var PUBLIC_RSPRESS_INTERCOM_APP_ID_

This chat was implemented using some simple customization:
![Screenshot from 2025-05-20 11-16-23](https://github.com/user-attachments/assets/25d738aa-6680-4920-88ae-c0911661a0be)
_customization_
So, we can tweak the design (based on its limitations)

![image](https://github.com/user-attachments/assets/5a8d8e8a-f985-4fe0-a8a6-78ac6ba8c241)
_utm data_

## How to test this PR?
Open the website and check for the right side chat button.
Send a message and check in the intercom messenger tab

## Checklist

- [x] I have added explaination of the changes I made
- [x] UI related: this PR has been visually reviewed for both web, mobile and tablet
