### PR TITLE
chore: bump form-data to >=4.0.4 to resolve security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
       "@tailwindcss/oxide",
       "core-js",
       "esbuild"
-    ]
+    ],
+    "overrides": {
+      "form-data": ">=4.0.4"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data: '>=4.0.4'
+
 importers:
 
   .:
@@ -1590,8 +1593,8 @@ packages:
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
-  form-data@4.0.3:
-    resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -3711,7 +3714,7 @@ snapshots:
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 24.0.3
-      form-data: 4.0.3
+      form-data: 4.0.4
 
   '@types/node@18.19.112':
     dependencies:
@@ -3866,7 +3869,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios-retry@4.5.0(axios@1.10.0):
+  axios-retry@4.5.0(axios@1.10.0(debug@4.4.1)):
     dependencies:
       axios: 1.10.0(debug@4.4.1)
       is-retry-allowed: 2.2.0
@@ -3874,7 +3877,7 @@ snapshots:
   axios@1.10.0(debug@4.4.1):
     dependencies:
       follow-redirects: 1.15.9(debug@4.4.1)
-      form-data: 4.0.3
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -4195,7 +4198,7 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
-  form-data@4.0.3:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -5567,7 +5570,7 @@ snapshots:
   zephyr-agent@0.0.56:
     dependencies:
       axios: 1.10.0(debug@4.4.1)
-      axios-retry: 4.5.0(axios@1.10.0)
+      axios-retry: 4.5.0(axios@1.10.0(debug@4.4.1))
       cloudflare: 3.5.0
       debug: 4.4.1
       git-url-parse: 15.0.0


### PR DESCRIPTION
## Summary
- Added form-data override to existing pnpm overrides to force version to >=4.0.4 to address security vulnerability in previous version

## Test plan
- [x] Updated package.json with pnpm override
- [x] Verified dependencies are updated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)