### PR TITLE
style: update H1–H5 typography to font-medium, leading-tighter, text-white

### DIFF
--- a/src/components/sections/BlogSection.tsx
+++ b/src/components/sections/BlogSection.tsx
@@ -18,7 +18,9 @@ export const BlogSection: React.FC = () => {
   return (
     <section className="py-20 md:py-28">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <h2 className="text-center text-3xl font-semibold text-white mb-4">Keep tabs on what we're shipping</h2>
+        <h2 className="text-center text-3xl font-medium leading-tighter text-white mb-4">
+          Keep tabs on what we're shipping
+        </h2>
         <p className="text-center mb-12">
           Follow us on{' '}
           <a

--- a/src/components/sections/CloudProvidersSection.tsx
+++ b/src/components/sections/CloudProvidersSection.tsx
@@ -80,7 +80,7 @@ export const CloudProvidersSection: React.FC = () => {
     <section className="cloudProviders py-20 bg-neutral-950">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
-          <h2 className="text-3xl font-bold mb-4">Deploy Anywhere</h2>
+          <h2 className="text-3xl font-medium leading-tighter text-white mb-4">Deploy Anywhere</h2>
           <p className="text-neutral-400 max-w-2xl mx-auto">
             Zephyr Cloud integrates seamlessly with leading cloud providers, enabling instant deployments and runtime
             updates across your preferred infrastructure.

--- a/src/components/sections/FeatureSection.tsx
+++ b/src/components/sections/FeatureSection.tsx
@@ -33,7 +33,7 @@ interface FeatureTitleProps {
 
 export const FeatureTitle: React.FC<FeatureTitleProps> = ({ children, prefix, className }) => {
   return (
-    <h2 className={cn('text-5xl font-bold text-white', className)}>
+    <h2 className={cn('text-5xl font-medium leading-tighter text-white', className)}>
       {prefix}
       {children}
     </h2>

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -17,7 +17,7 @@ export const Footer: React.FC = () => {
             <p className="text-xs text-neutral-500">&copy; {new Date().getFullYear()} Zephyr Cloud, Inc.</p>
           </div>
           <div>
-            <h5 className="font-semibold text-white mb-3">Developers</h5>
+            <h5 className="font-medium text-white mb-3">Developers</h5>
             <ul className="space-y-2 text-sm">
               <li>
                 <a href="https://docs.zephyr-cloud.io/" target="_blank" className="text-neutral-400 hover:text-white">
@@ -32,7 +32,7 @@ export const Footer: React.FC = () => {
             </ul>
           </div>
           <div>
-            <h5 className="font-semibold text-white mb-3">Company</h5>
+            <h5 className="font-medium text-white mb-3">Company</h5>
             <ul className="space-y-2 text-sm">
               <li>
                 <a
@@ -83,7 +83,7 @@ export const Footer: React.FC = () => {
             </ul>
           </div>
           <div>
-            <h5 className="font-semibold text-white mb-3">Legal</h5>
+            <h5 className="font-medium text-white mb-3">Legal</h5>
             <ul className="space-y-2 text-sm">
               <li>
                 <Link to="/privacy" className="text-neutral-400 hover:text-white">

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -79,12 +79,10 @@ export const HeroSection: React.FC = () => {
           </div>
         )}
 
-        <h1 className="text-5xl md:text-6xl font-bold text-white leading-tight uppercase">
+        <h1 className="text-5xl md:text-6xl font-medium text-white leading-tighter">
           The fastest way to go from
           <br />
-          <span className="bg-gradient-to-b from-green-300 via-emerald-500 to-emerald-800 bg-clip-text text-transparent drop-shadow-[0_0_24px_rgba(16,185,129,0.3)]">
-            Idea to Production
-          </span>
+          <span>Idea to Production</span>
         </h1>
         <p className="mt-6 text-lg md:text-xl max-w-2xl mx-auto">
           From the team that brought you{' '}

--- a/src/components/sections/TestimonialsSection.tsx
+++ b/src/components/sections/TestimonialsSection.tsx
@@ -72,7 +72,7 @@ export const TestimonialsSection: React.FC = () => {
         style={{ background: 'radial-gradient(ellipse 80% 60% at 50% 50%, #0d2d1f 0%, #0a0a0a 70%)' }}
       >
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 mb-12">
-          <h2 className="text-center text-2xl font-semibold text-white uppercase">You can just ship</h2>
+          <h2 className="text-center text-2xl font-medium leading-tighter text-white">You can just ship</h2>
         </div>
 
         {/* Scrolling testimonials container */}
@@ -185,7 +185,7 @@ export const TestimonialsSection: React.FC = () => {
 
       <section className="companies">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 mt-20 mb-12">
-          <h2 className="text-center text-2xl font-semibold text-white uppercase">Some folks who love Zephyr</h2>
+          <h2 className="text-center text-2xl font-medium leading-tighter text-white">Some folks who love Zephyr</h2>
         </div>
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="mt-12 flex flex-wrap justify-center items-center gap-x-20 gap-y-10">

--- a/src/index.css
+++ b/src/index.css
@@ -45,7 +45,7 @@ body {
 
 .content h1 {
   font-size: 3.6rem;
-  font-weight: 700;
+  font-weight: 500;
 }
 
 .content p {
@@ -122,6 +122,7 @@ body {
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
   --animate-shine: shine var(--duration) infinite linear;
+  --leading-tighter: 1.1;
 
   @keyframes shine {
     0% {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -87,10 +87,11 @@ function TwitterEmbed({ children, mediaMaxWidth = 560 }: { children: ReactNode; 
 
 // MDX components configuration
 const mdxComponents = {
-  h1: (props: any) => <h1 className="text-4xl font-bold mb-6 text-white" {...props} />,
-  h2: (props: any) => <h2 className="text-3xl font-semibold mb-4 mt-8 text-white" {...props} />,
-  h3: (props: any) => <h3 className="text-2xl font-semibold mb-3 mt-6 text-white" {...props} />,
-  h4: (props: any) => <h4 className="text-xl font-semibold mb-2 mt-4 text-white" {...props} />,
+  h1: (props: any) => <h1 className="text-4xl font-medium leading-tighter mb-6 text-white" {...props} />,
+  h2: (props: any) => <h2 className="text-3xl font-medium leading-tighter mb-4 mt-8 text-white" {...props} />,
+  h3: (props: any) => <h3 className="text-2xl font-medium leading-tighter mb-3 mt-6 text-white" {...props} />,
+  h4: (props: any) => <h4 className="text-xl font-medium leading-tighter mb-2 mt-4 text-white" {...props} />,
+  h5: (props: any) => <h5 className="text-lg font-medium leading-tighter mb-2 mt-4 text-white" {...props} />,
   p: (props: any) => <p className="mb-4 text-neutral-300 leading-relaxed" {...props} />,
   ul: (props: any) => <ul className="list-disc list-inside mb-4 text-neutral-300" {...props} />,
   ol: (props: any) => <ol className="list-decimal list-inside mb-4 text-neutral-300" {...props} />,

--- a/src/routes/blog/index.tsx
+++ b/src/routes/blog/index.tsx
@@ -53,9 +53,7 @@ function BlogPage() {
       <div className="container mx-auto px-4 py-16 max-w-7xl">
         {/* Header */}
         <div className="text-center mb-12">
-          <h1 className="text-5xl font-bold mb-4 bg-gradient-to-r pb-2 from-emerald-400 to-emerald-600 bg-clip-text text-transparent">
-            Blog
-          </h1>
+          <h1 className="text-5xl font-medium leading-tighter mb-4 text-white">Blog</h1>
           <p className="text-xl text-neutral-400">Insights, updates, and tutorials from the Zephyr team</p>
         </div>
 

--- a/src/routes/changelog/index.tsx
+++ b/src/routes/changelog/index.tsx
@@ -73,9 +73,7 @@ function ChangelogPage() {
       <div className="container mx-auto px-4 py-16 max-w-7xl">
         {/* Header */}
         <div className="text-center mb-16">
-          <h1 className="text-5xl font-bold mb-4 pb-2 bg-gradient-to-r from-emerald-400 to-emerald-600 bg-clip-text text-transparent">
-            Changelog
-          </h1>
+          <h1 className="text-5xl font-medium leading-tighter mb-4 text-white">Changelog</h1>
           <p className="text-xl text-neutral-400">Latest updates and improvements to Zephyr Cloud</p>
         </div>
 

--- a/src/routes/events.tsx
+++ b/src/routes/events.tsx
@@ -216,9 +216,7 @@ function EventsPage() {
 
         <div className="relative container mx-auto px-4 py-24 max-w-6xl">
           <div className="max-w-3xl">
-            <h1 className="text-5xl lg:text-6xl font-bold mb-6 bg-gradient-to-br from-white to-neutral-400 bg-clip-text text-transparent">
-              Build, Ship, Connect
-            </h1>
+            <h1 className="text-5xl lg:text-6xl font-medium leading-tighter mb-6 text-white">Build, Ship, Connect</h1>
             <p className="text-xl text-neutral-300 mb-8">
               Join our Zephyr Cloud community at conferences, workshops, and meetups worldwide.
             </p>

--- a/src/routes/press.tsx
+++ b/src/routes/press.tsx
@@ -11,9 +11,7 @@ function PressPage() {
       <div className="container mx-auto px-4 py-16 max-w-6xl">
         {/* Header */}
         <div className="text-center mb-12">
-          <h1 className="text-5xl font-bold mb-4 bg-gradient-to-r from-emerald-400 to-emerald-600 bg-clip-text text-transparent">
-            Press
-          </h1>
+          <h1 className="text-5xl font-medium leading-tighter mb-4 text-white">Press</h1>
           <p className="text-xl text-neutral-400 mb-8">Latest news and announcements from Zephyr Cloud</p>
 
           {/* Contact */}

--- a/src/routes/products/code-elimination-performance.tsx
+++ b/src/routes/products/code-elimination-performance.tsx
@@ -16,7 +16,7 @@ function CodeEliminationPerformancePage() {
               <Zap className="w-12 h-12 text-white" />
             </div>
           </div>
-          <h1 className="text-5xl font-bold mb-4 bg-gradient-to-r from-violet-400 to-purple-600 bg-clip-text text-transparent">
+          <h1 className="text-5xl font-medium leading-tighter mb-4 text-white">
             Enterprise Scale Code Elimination & Performance
           </h1>
           <p className="text-xl text-neutral-400 max-w-3xl mx-auto">


### PR DESCRIPTION
<!-- Created by open-pr command -->

## What's added in this PR?

Typography refresh across all H1–H5 headings site-wide:

- **Font weight**: `font-bold` / `font-semibold` → `font-medium` on all headings
- **Line height**: added `leading-tighter` (`1.1`) via new `--leading-tighter` Tailwind v4 `@theme` token
- **Color**: all gradient text headings replaced with plain `text-white` (hero, press, blog, changelog, events, products)
- **Case**: removed `uppercase` from hero H1 and testimonial H2s (sentence case)
- **H5**: added missing h5 MDX component

## What's the issue related to this PR?

Design consistency — headings lacked a unified weight, line-height, and color treatment across pages.

## How to test this PR?

Preview: https://edward-grosse-10-zephyr-landing-zephyr-website-ze-6fc63cf17-ze.zephyr-cloud.io

1. Check home page hero, feature sections, testimonials, and footer headings
2. Check `/blog`, `/changelog`, `/press`, `/events`, `/products/code-elimination-performance`
3. Verify no gradient text remains on any H1–H5

## Checklist

- [x] I have added explanation of the changes I made
- [ ] UI related: this PR has been visually reviewed for both web, mobile, and tablet