### PR TITLE
fix: add missing AWS docs link in cloud providers section

### DIFF
--- a/src/components/sections/CloudProvidersSection.tsx
+++ b/src/components/sections/CloudProvidersSection.tsx
@@ -38,6 +38,7 @@ const cloudProviders: CloudProvider[] = [
     name: 'AWS',
     status: 'available',
     logo: aws,
+    docsLink: 'https://docs.zephyr-cloud.io/cloud/aws',
   },
   {
     name: 'Vercel',


### PR DESCRIPTION
## Summary

- AWS card in the Cloud Providers section was missing its `docsLink`, causing it to render as a non-clickable div with no external link indicator on hover
- Adds `docsLink: 'https://docs.zephyr-cloud.io/cloud/aws'` to match the pattern used by Cloudflare, Fastly, and Akamai

## Test plan
- [ ] AWS card is now clickable and links to the AWS docs page
- [ ] External link icon appears on hover (same as other providers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)