### PR TITLE
Pricing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,56 @@
   animation-play-state: paused;
 }
 
+/* ─── Calculator output — responsive two-column (desktop) / stacked (mobile) ── */
+.calc-output {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  row-gap: var(--spacing-2, 8px);
+  margin-bottom: var(--spacing-2, 8px);
+}
+
+.calc-output-label,
+.calc-output-switch {
+  align-self: center;
+}
+
+.calc-output-switch {
+  justify-self: end;
+}
+
+.calc-output-number {
+  grid-column: 1 / -1;
+}
+
+.calc-output-rate {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4, 16px);
+  flex-wrap: wrap;
+}
+
+@media (min-width: 640px) {
+  .calc-output-number {
+    grid-column: 1;
+    align-self: end;
+  }
+
+  .calc-output-rate {
+    grid-column: 2;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: var(--spacing-1, 4px);
+    justify-self: end;
+    align-self: end;
+  }
+}
+
+html,
+body {
+  overflow-x: hidden;
+}
+
 body {
   margin: 0;
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -8,126 +8,127 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as BlogSlugRouteImport } from './routes/blog/$slug';
-import { Route as BlogIndexRouteImport } from './routes/blog/index';
-import { Route as ChangelogSlugRouteImport } from './routes/changelog/$slug';
-import { Route as ChangelogIndexRouteImport } from './routes/changelog/index';
-import { Route as EventsRouteImport } from './routes/events';
-import { Route as IndexRouteImport } from './routes/index';
-import { Route as PartnersRouteImport } from './routes/partners';
-import { Route as PressRouteImport } from './routes/press';
-import { Route as PricingRouteImport } from './routes/pricing';
-import { Route as PrivacyRouteImport } from './routes/privacy';
-import { Route as ProductsAiRouteImport } from './routes/products/ai';
-import { Route as ProductsCodeEliminationPerformanceRouteImport } from './routes/products/code-elimination-performance';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as PrivacyRouteImport } from './routes/privacy'
+import { Route as PricingRouteImport } from './routes/pricing'
+import { Route as PressRouteImport } from './routes/press'
+import { Route as PartnersRouteImport } from './routes/partners'
+import { Route as EventsRouteImport } from './routes/events'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as ChangelogIndexRouteImport } from './routes/changelog/index'
+import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as ProductsCodeEliminationPerformanceRouteImport } from './routes/products/code-elimination-performance'
+import { Route as ProductsAiRouteImport } from './routes/products/ai'
+import { Route as ChangelogSlugRouteImport } from './routes/changelog/$slug'
+import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 
 const PrivacyRoute = PrivacyRouteImport.update({
   id: '/privacy',
   path: '/privacy',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const PricingRoute = PricingRouteImport.update({
   id: '/pricing',
   path: '/pricing',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const PressRoute = PressRouteImport.update({
   id: '/press',
   path: '/press',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const PartnersRoute = PartnersRouteImport.update({
   id: '/partners',
   path: '/partners',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const EventsRoute = EventsRouteImport.update({
   id: '/events',
   path: '/events',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ChangelogIndexRoute = ChangelogIndexRouteImport.update({
   id: '/changelog/',
   path: '/changelog/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const BlogIndexRoute = BlogIndexRouteImport.update({
   id: '/blog/',
   path: '/blog/',
   getParentRoute: () => rootRouteImport,
-} as any);
-const ProductsCodeEliminationPerformanceRoute = ProductsCodeEliminationPerformanceRouteImport.update({
-  id: '/products/code-elimination-performance',
-  path: '/products/code-elimination-performance',
-  getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
+const ProductsCodeEliminationPerformanceRoute =
+  ProductsCodeEliminationPerformanceRouteImport.update({
+    id: '/products/code-elimination-performance',
+    path: '/products/code-elimination-performance',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ProductsAiRoute = ProductsAiRouteImport.update({
   id: '/products/ai',
   path: '/products/ai',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ChangelogSlugRoute = ChangelogSlugRouteImport.update({
   id: '/changelog/$slug',
   path: '/changelog/$slug',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const BlogSlugRoute = BlogSlugRouteImport.update({
   id: '/blog/$slug',
   path: '/blog/$slug',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute;
-  '/events': typeof EventsRoute;
-  '/partners': typeof PartnersRoute;
-  '/press': typeof PressRoute;
-  '/pricing': typeof PricingRoute;
-  '/privacy': typeof PrivacyRoute;
-  '/blog/$slug': typeof BlogSlugRoute;
-  '/changelog/$slug': typeof ChangelogSlugRoute;
-  '/products/ai': typeof ProductsAiRoute;
-  '/products/code-elimination-performance': typeof ProductsCodeEliminationPerformanceRoute;
-  '/blog/': typeof BlogIndexRoute;
-  '/changelog/': typeof ChangelogIndexRoute;
+  '/': typeof IndexRoute
+  '/events': typeof EventsRoute
+  '/partners': typeof PartnersRoute
+  '/press': typeof PressRoute
+  '/pricing': typeof PricingRoute
+  '/privacy': typeof PrivacyRoute
+  '/blog/$slug': typeof BlogSlugRoute
+  '/changelog/$slug': typeof ChangelogSlugRoute
+  '/products/ai': typeof ProductsAiRoute
+  '/products/code-elimination-performance': typeof ProductsCodeEliminationPerformanceRoute
+  '/blog/': typeof BlogIndexRoute
+  '/changelog/': typeof ChangelogIndexRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute;
-  '/events': typeof EventsRoute;
-  '/partners': typeof PartnersRoute;
-  '/press': typeof PressRoute;
-  '/pricing': typeof PricingRoute;
-  '/privacy': typeof PrivacyRoute;
-  '/blog/$slug': typeof BlogSlugRoute;
-  '/changelog/$slug': typeof ChangelogSlugRoute;
-  '/products/ai': typeof ProductsAiRoute;
-  '/products/code-elimination-performance': typeof ProductsCodeEliminationPerformanceRoute;
-  '/blog': typeof BlogIndexRoute;
-  '/changelog': typeof ChangelogIndexRoute;
+  '/': typeof IndexRoute
+  '/events': typeof EventsRoute
+  '/partners': typeof PartnersRoute
+  '/press': typeof PressRoute
+  '/pricing': typeof PricingRoute
+  '/privacy': typeof PrivacyRoute
+  '/blog/$slug': typeof BlogSlugRoute
+  '/changelog/$slug': typeof ChangelogSlugRoute
+  '/products/ai': typeof ProductsAiRoute
+  '/products/code-elimination-performance': typeof ProductsCodeEliminationPerformanceRoute
+  '/blog': typeof BlogIndexRoute
+  '/changelog': typeof ChangelogIndexRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  '/': typeof IndexRoute;
-  '/events': typeof EventsRoute;
-  '/partners': typeof PartnersRoute;
-  '/press': typeof PressRoute;
-  '/pricing': typeof PricingRoute;
-  '/privacy': typeof PrivacyRoute;
-  '/blog/$slug': typeof BlogSlugRoute;
-  '/changelog/$slug': typeof ChangelogSlugRoute;
-  '/products/ai': typeof ProductsAiRoute;
-  '/products/code-elimination-performance': typeof ProductsCodeEliminationPerformanceRoute;
-  '/blog/': typeof BlogIndexRoute;
-  '/changelog/': typeof ChangelogIndexRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/events': typeof EventsRoute
+  '/partners': typeof PartnersRoute
+  '/press': typeof PressRoute
+  '/pricing': typeof PricingRoute
+  '/privacy': typeof PrivacyRoute
+  '/blog/$slug': typeof BlogSlugRoute
+  '/changelog/$slug': typeof ChangelogSlugRoute
+  '/products/ai': typeof ProductsAiRoute
+  '/products/code-elimination-performance': typeof ProductsCodeEliminationPerformanceRoute
+  '/blog/': typeof BlogIndexRoute
+  '/changelog/': typeof ChangelogIndexRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/events'
@@ -140,8 +141,8 @@ export interface FileRouteTypes {
     | '/products/ai'
     | '/products/code-elimination-performance'
     | '/blog/'
-    | '/changelog/';
-  fileRoutesByTo: FileRoutesByTo;
+    | '/changelog/'
+  fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/events'
@@ -154,7 +155,7 @@ export interface FileRouteTypes {
     | '/products/ai'
     | '/products/code-elimination-performance'
     | '/blog'
-    | '/changelog';
+    | '/changelog'
   id:
     | '__root__'
     | '/'
@@ -168,110 +169,110 @@ export interface FileRouteTypes {
     | '/products/ai'
     | '/products/code-elimination-performance'
     | '/blog/'
-    | '/changelog/';
-  fileRoutesById: FileRoutesById;
+    | '/changelog/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  EventsRoute: typeof EventsRoute;
-  PartnersRoute: typeof PartnersRoute;
-  PressRoute: typeof PressRoute;
-  PricingRoute: typeof PricingRoute;
-  PrivacyRoute: typeof PrivacyRoute;
-  BlogSlugRoute: typeof BlogSlugRoute;
-  ChangelogSlugRoute: typeof ChangelogSlugRoute;
-  ProductsAiRoute: typeof ProductsAiRoute;
-  ProductsCodeEliminationPerformanceRoute: typeof ProductsCodeEliminationPerformanceRoute;
-  BlogIndexRoute: typeof BlogIndexRoute;
-  ChangelogIndexRoute: typeof ChangelogIndexRoute;
+  IndexRoute: typeof IndexRoute
+  EventsRoute: typeof EventsRoute
+  PartnersRoute: typeof PartnersRoute
+  PressRoute: typeof PressRoute
+  PricingRoute: typeof PricingRoute
+  PrivacyRoute: typeof PrivacyRoute
+  BlogSlugRoute: typeof BlogSlugRoute
+  ChangelogSlugRoute: typeof ChangelogSlugRoute
+  ProductsAiRoute: typeof ProductsAiRoute
+  ProductsCodeEliminationPerformanceRoute: typeof ProductsCodeEliminationPerformanceRoute
+  BlogIndexRoute: typeof BlogIndexRoute
+  ChangelogIndexRoute: typeof ChangelogIndexRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/privacy': {
-      id: '/privacy';
-      path: '/privacy';
-      fullPath: '/privacy';
-      preLoaderRoute: typeof PrivacyRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/pricing': {
-      id: '/pricing';
-      path: '/pricing';
-      fullPath: '/pricing';
-      preLoaderRoute: typeof PricingRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/pricing'
+      path: '/pricing'
+      fullPath: '/pricing'
+      preLoaderRoute: typeof PricingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/press': {
-      id: '/press';
-      path: '/press';
-      fullPath: '/press';
-      preLoaderRoute: typeof PressRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/press'
+      path: '/press'
+      fullPath: '/press'
+      preLoaderRoute: typeof PressRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/partners': {
-      id: '/partners';
-      path: '/partners';
-      fullPath: '/partners';
-      preLoaderRoute: typeof PartnersRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/partners'
+      path: '/partners'
+      fullPath: '/partners'
+      preLoaderRoute: typeof PartnersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/events': {
-      id: '/events';
-      path: '/events';
-      fullPath: '/events';
-      preLoaderRoute: typeof EventsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/events'
+      path: '/events'
+      fullPath: '/events'
+      preLoaderRoute: typeof EventsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
-      id: '/';
-      path: '/';
-      fullPath: '/';
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/changelog/': {
-      id: '/changelog/';
-      path: '/changelog';
-      fullPath: '/changelog/';
-      preLoaderRoute: typeof ChangelogIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/changelog/'
+      path: '/changelog'
+      fullPath: '/changelog/'
+      preLoaderRoute: typeof ChangelogIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/blog/': {
-      id: '/blog/';
-      path: '/blog';
-      fullPath: '/blog/';
-      preLoaderRoute: typeof BlogIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/blog/'
+      path: '/blog'
+      fullPath: '/blog/'
+      preLoaderRoute: typeof BlogIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/products/code-elimination-performance': {
-      id: '/products/code-elimination-performance';
-      path: '/products/code-elimination-performance';
-      fullPath: '/products/code-elimination-performance';
-      preLoaderRoute: typeof ProductsCodeEliminationPerformanceRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/products/code-elimination-performance'
+      path: '/products/code-elimination-performance'
+      fullPath: '/products/code-elimination-performance'
+      preLoaderRoute: typeof ProductsCodeEliminationPerformanceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/products/ai': {
-      id: '/products/ai';
-      path: '/products/ai';
-      fullPath: '/products/ai';
-      preLoaderRoute: typeof ProductsAiRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/products/ai'
+      path: '/products/ai'
+      fullPath: '/products/ai'
+      preLoaderRoute: typeof ProductsAiRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/changelog/$slug': {
-      id: '/changelog/$slug';
-      path: '/changelog/$slug';
-      fullPath: '/changelog/$slug';
-      preLoaderRoute: typeof ChangelogSlugRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/changelog/$slug'
+      path: '/changelog/$slug'
+      fullPath: '/changelog/$slug'
+      preLoaderRoute: typeof ChangelogSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/blog/$slug': {
-      id: '/blog/$slug';
-      path: '/blog/$slug';
-      fullPath: '/blog/$slug';
-      preLoaderRoute: typeof BlogSlugRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/blog/$slug'
+      path: '/blog/$slug'
+      fullPath: '/blog/$slug'
+      preLoaderRoute: typeof BlogSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -285,8 +286,11 @@ const rootRouteChildren: RootRouteChildren = {
   BlogSlugRoute: BlogSlugRoute,
   ChangelogSlugRoute: ChangelogSlugRoute,
   ProductsAiRoute: ProductsAiRoute,
-  ProductsCodeEliminationPerformanceRoute: ProductsCodeEliminationPerformanceRoute,
+  ProductsCodeEliminationPerformanceRoute:
+    ProductsCodeEliminationPerformanceRoute,
   BlogIndexRoute: BlogIndexRoute,
   ChangelogIndexRoute: ChangelogIndexRoute,
-};
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>();
+}
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -507,7 +507,7 @@ function PricingPage() {
         <div className="tier-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 14 }}>
           {/* FREE */}
           <div style={card()}>
-            <div style={{ minHeight: 185 }}>
+            <div style={{ minHeight: 220 }}>
               <TierName>Free</TierName>
               <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2, visibility: 'hidden' }}>
                 starting at
@@ -563,7 +563,7 @@ function PricingPage() {
             >
               Most Popular
             </div>
-            <div style={{ minHeight: 185 }}>
+            <div style={{ minHeight: 220 }}>
               <TierName purple>Teams</TierName>
               <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
               <div style={amt()}>{isAnnual ? fmt(Math.round(PRO_INTRO * ANNUAL_DISC)) : fmt(PRO_INTRO)}</div>
@@ -635,7 +635,7 @@ function PricingPage() {
             >
               For Growing Teams
             </div>
-            <div style={{ minHeight: 185 }}>
+            <div style={{ minHeight: 220 }}>
               <TierName amber>Business</TierName>
               <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
               <div style={amt()}>{isAnnual ? fmt(Math.round(BIZ_INTRO * ANNUAL_DISC)) : fmt(BIZ_INTRO)}</div>
@@ -672,7 +672,7 @@ function PricingPage() {
 
           {/* ENTERPRISE */}
           <div style={card()}>
-            <div style={{ minHeight: 185 }}>
+            <div style={{ minHeight: 220 }}>
               <TierName>Enterprise</TierName>
               <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2, visibility: 'hidden' }}>
                 starting at

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -511,9 +511,6 @@ function PricingPage() {
             <div style={amt()}>$0</div>
             <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>forever</div>
             <TierSeats>1 seat · no credit card required</TierSeats>
-            <p style={desc()}>
-              For individuals exploring Zephyr. Full BYOC, all bundlers, and tag-based environments — free forever.
-            </p>
             <Cta href="https://app.zephyr-cloud.io/" v="secondary">
               Get started free
             </Cta>
@@ -571,10 +568,6 @@ function PricingPage() {
               </a>
             </div>
             <TierSeats>2 – 75 seats · costs decrease as your team scales</TierSeats>
-            <p style={desc()}>
-              The full deployment platform. MF-native features, BYOC, per-team permissions, and audit logs — everything
-              a shipping team needs.
-            </p>
             <Cta href="https://app.zephyr-cloud.io/" v="primary">
               Start free 30-day trial
             </Cta>
@@ -661,10 +654,6 @@ function PricingPage() {
               </a>
             </div>
             <TierSeats>2 – 200 seats · SSO, SLAs, and governance included</TierSeats>
-            <p style={desc()}>
-              For teams that need SSO, approval workflows, and SLA guarantees. The governance layer between Pro and
-              Enterprise — without the Enterprise price tag.
-            </p>
             <Cta href="https://app.zephyr-cloud.io/" v="amber">
               Start free 30-day trial
             </Cta>
@@ -702,10 +691,6 @@ function PricingPage() {
             <div style={amt()}>Custom</div>
             <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>&nbsp;</div>
             <TierSeats>200+ seats · no RFP required · quote same day</TierSeats>
-            <p style={desc()}>
-              For large orgs and regulated sectors. SOC 2, DPA, dedicated CSM, and custom SLAs. Pay by invoice. POC /
-              pilot available.
-            </p>
             <Cta href="mailto:inbound@zephyr-cloud.io?subject=Enterprise" v="secondary">
               Talk to sales
             </Cta>
@@ -1484,9 +1469,10 @@ const card = () => ({
   borderRadius: 14,
   padding: '32px 28px',
   position: 'relative' as const,
+  display: 'flex',
+  flexDirection: 'column' as const,
 });
 const amt = () => ({ fontSize: 48, fontWeight: 900, letterSpacing: '-2px', color: C.white, lineHeight: 1 });
-const desc = () => ({ fontSize: 13, color: C.gray, lineHeight: 1.65, marginBottom: 24 });
 const featList = () => ({
   listStyle: 'none' as const,
   display: 'flex' as const,
@@ -1552,6 +1538,7 @@ function Cta({
         fontSize: 14,
         fontWeight: 700,
         textDecoration: 'none',
+        marginTop: 'auto',
         marginBottom: 24,
         transition: 'all 0.2s',
         ...(v === 'primary'

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -507,10 +507,15 @@ function PricingPage() {
         <div className="tier-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 14 }}>
           {/* FREE */}
           <div style={card()}>
-            <TierName>Free</TierName>
-            <div style={amt()}>$0</div>
-            <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>forever</div>
-            <TierSeats>1 seat · no credit card required</TierSeats>
+            <div style={{ minHeight: 185 }}>
+              <TierName>Free</TierName>
+              <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2, visibility: 'hidden' }}>
+                starting at
+              </div>
+              <div style={amt()}>$0</div>
+              <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>forever</div>
+              <TierSeats>1 seat · no credit card required</TierSeats>
+            </div>
             <Cta href="https://app.zephyr-cloud.io/" v="secondary">
               Get started free
             </Cta>
@@ -558,31 +563,21 @@ function PricingPage() {
             >
               Most Popular
             </div>
-            <TierName purple>Teams</TierName>
-            <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
-            <div style={amt()}>{isAnnual ? fmt(Math.round(PRO_INTRO * ANNUAL_DISC)) : fmt(PRO_INTRO)}</div>
-            <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>
-              per seat / month ·{' '}
-              <a href="#calc" style={{ color: C.purpleLight, textDecoration: 'none', fontWeight: 600 }}>
-                use the calculator ↓
-              </a>
+            <div style={{ minHeight: 185 }}>
+              <TierName purple>Teams</TierName>
+              <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
+              <div style={amt()}>{isAnnual ? fmt(Math.round(PRO_INTRO * ANNUAL_DISC)) : fmt(PRO_INTRO)}</div>
+              <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>
+                per seat / month ·{' '}
+                <a href="#calc" style={{ color: C.purpleLight, textDecoration: 'none', fontWeight: 600 }}>
+                  calculator ↓
+                </a>
+              </div>
+              <TierSeats>2 – 75 seats · costs decrease as your team scales</TierSeats>
             </div>
-            <TierSeats>2 – 75 seats · costs decrease as your team scales</TierSeats>
             <Cta href="https://app.zephyr-cloud.io/" v="primary">
               Start free 30-day trial
             </Cta>
-            <div
-              style={{
-                fontSize: 11,
-                color: C.grayDark,
-                textAlign: 'center',
-                marginTop: -16,
-                marginBottom: 16,
-                lineHeight: 1.5,
-              }}
-            >
-              No credit card required · full Pro access
-            </div>
             <ul style={featList()}>
               <Fi c="green">
                 <strong style={{ color: C.white }}>BYOC</strong> — all cloud integrations
@@ -640,35 +635,25 @@ function PricingPage() {
             >
               For Growing Teams
             </div>
-            <TierName amber>Business</TierName>
-            <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
-            <div style={amt()}>{isAnnual ? fmt(Math.round(BIZ_INTRO * ANNUAL_DISC)) : fmt(BIZ_INTRO)}</div>
-            <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>
-              per seat / month ·{' '}
-              <a
-                href="#calc"
-                onClick={() => setCalcTab('biz')}
-                style={{ color: C.amber, textDecoration: 'none', fontWeight: 600 }}
-              >
-                use the calculator ↓
-              </a>
+            <div style={{ minHeight: 185 }}>
+              <TierName amber>Business</TierName>
+              <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
+              <div style={amt()}>{isAnnual ? fmt(Math.round(BIZ_INTRO * ANNUAL_DISC)) : fmt(BIZ_INTRO)}</div>
+              <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>
+                per seat / month ·{' '}
+                <a
+                  href="#calc"
+                  onClick={() => setCalcTab('biz')}
+                  style={{ color: C.amber, textDecoration: 'none', fontWeight: 600 }}
+                >
+                  calculator ↓
+                </a>
+              </div>
+              <TierSeats>2 – 200 seats · SSO, SLAs, and governance included</TierSeats>
             </div>
-            <TierSeats>2 – 200 seats · SSO, SLAs, and governance included</TierSeats>
             <Cta href="https://app.zephyr-cloud.io/" v="amber">
               Start free 30-day trial
             </Cta>
-            <div
-              style={{
-                fontSize: 11,
-                color: C.grayDark,
-                textAlign: 'center',
-                marginTop: -16,
-                marginBottom: 16,
-                lineHeight: 1.5,
-              }}
-            >
-              No credit card required · full Business access
-            </div>
             <ul style={featList()}>
               <Fi c="amber">
                 <strong style={{ color: C.white }}>Everything in Teams</strong>
@@ -687,10 +672,15 @@ function PricingPage() {
 
           {/* ENTERPRISE */}
           <div style={card()}>
-            <TierName>Enterprise</TierName>
-            <div style={amt()}>Custom</div>
-            <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>&nbsp;</div>
-            <TierSeats>200+ seats · no RFP required · quote same day</TierSeats>
+            <div style={{ minHeight: 185 }}>
+              <TierName>Enterprise</TierName>
+              <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2, visibility: 'hidden' }}>
+                starting at
+              </div>
+              <div style={amt()}>Custom</div>
+              <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>&nbsp;</div>
+              <TierSeats>200+ seats · no RFP required · quote same day</TierSeats>
+            </div>
             <Cta href="mailto:inbound@zephyr-cloud.io?subject=Enterprise" v="secondary">
               Talk to sales
             </Cta>
@@ -1538,7 +1528,6 @@ function Cta({
         fontSize: 14,
         fontWeight: 700,
         textDecoration: 'none',
-        marginTop: 'auto',
         marginBottom: 24,
         transition: 'all 0.2s',
         ...(v === 'primary'

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -180,47 +180,6 @@ function PricingPage() {
         <p style={{ fontSize: 14, color: C.gray, maxWidth: 520, margin: '0 auto 14px', lineHeight: 1.65 }}>
           Start free and scale as you grow.
         </p>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            flexWrap: 'nowrap',
-            gap: 0,
-            background: 'linear-gradient(135deg, #1A0F3A 0%, #0F0F1A 100%)',
-            border: `1px solid rgba(139,92,246,0.25)`,
-            borderRadius: 12,
-            padding: '14px 32px',
-            maxWidth: 860,
-            margin: '0 auto 20px',
-            overflowX: 'auto',
-          }}
-        >
-          {(
-            [
-              { icon: '∞', label: 'No build minutes' },
-              { icon: '⚡', label: 'Sub-second deployments' },
-              { icon: '☁', label: 'Bring Your Own Cloud (BYOC)' },
-              { icon: '✦', label: 'Unlimited preview environments' },
-            ] as { icon: string; label: string }[]
-          ).map(({ icon, label }) => (
-            <span
-              key={label}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 7,
-                fontSize: 13,
-                color: C.gray,
-                whiteSpace: 'nowrap',
-              }}
-            >
-              <span style={{ color: C.purpleLight, fontSize: 15 }}>{icon}</span>
-              {label}
-            </span>
-          ))}
-        </div>
-
         {/* Path selector */}
         <div style={{ display: 'flex', gap: 14, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 16 }}>
           {(
@@ -304,6 +263,39 @@ function PricingPage() {
           </p>
         )}
       </section>
+
+      {/* ── FEATURE BAR ── */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-evenly',
+          flexWrap: 'nowrap',
+          background: 'linear-gradient(135deg, #1A0F3A 0%, #0F0F1A 100%)',
+          borderTop: `1px solid rgba(139,92,246,0.2)`,
+          borderBottom: `1px solid rgba(139,92,246,0.2)`,
+          padding: '16px 40px',
+          width: '100%',
+          marginBottom: 0,
+        }}
+      >
+        {(
+          [
+            { icon: '∞', label: 'No build minutes' },
+            { icon: '⚡', label: 'Sub-second deployments' },
+            { icon: '☁', label: 'Bring Your Own Cloud (BYOC)' },
+            { icon: '✦', label: 'Unlimited preview environments' },
+          ] as { icon: string; label: string }[]
+        ).map(({ icon, label }) => (
+          <span
+            key={label}
+            style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: C.gray, whiteSpace: 'nowrap' }}
+          >
+            <span style={{ color: C.purpleLight, fontSize: 15 }}>{icon}</span>
+            {label}
+          </span>
+        ))}
+      </div>
 
       {/* ── VALUE PANELS ── */}
       <div ref={panelsRef}>

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -175,14 +175,46 @@ function PricingPage() {
             marginBottom: 10,
           }}
         >
-          Pricing that scales
-          <br />
-          with your team. <em style={{ fontStyle: 'normal', color: C.purpleLight }}>Not against it.</em>
+          Pricing that scales with your team
         </h1>
-        <p style={{ fontSize: 14, color: C.gray, maxWidth: 520, margin: '0 auto 20px', lineHeight: 1.65 }}>
-          Start free. The more your team grows, the less you pay per seat — and every tier is justified by what's
-          included.
+        <p style={{ fontSize: 14, color: C.gray, maxWidth: 520, margin: '0 auto 14px', lineHeight: 1.65 }}>
+          Start free and scale as you grow.
         </p>
+        <div style={{ display: 'flex', gap: 10, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 20 }}>
+          {[
+            'No build minutes',
+            'Sub-second deployments',
+            'Bring Your Own Cloud (BYOC)',
+            'Unlimited preview environments',
+          ].map((f) => (
+            <span
+              key={f}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                fontSize: 12,
+                color: C.gray,
+                background: C.black2,
+                border: `1px solid ${C.border}`,
+                borderRadius: 20,
+                padding: '4px 12px',
+              }}
+            >
+              <span
+                style={{
+                  width: 5,
+                  height: 5,
+                  borderRadius: '50%',
+                  background: C.green,
+                  flexShrink: 0,
+                  display: 'inline-block',
+                }}
+              />
+              {f}
+            </span>
+          ))}
+        </div>
 
         {/* Path selector */}
         <div style={{ display: 'flex', gap: 14, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 16 }}>

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1025,6 +1025,105 @@ function PricingPage() {
               <div style={{ textAlign: 'center', marginTop: 16, fontSize: 13, color: 'var(--muted-foreground)' }}>
                 No credit card required · free 30-day trial
               </div>
+
+              {/* ── VALUE METRICS ── */}
+              {(() => {
+                const seats = calcTab === 'pro' ? proSeats : bizSeats;
+                const annualCost = calcTab === 'pro' ? proYearly : bizYearly;
+                const acColor = calcTab === 'pro' ? 'var(--primary)' : 'var(--muted-foreground)';
+                const acRgb = calcTab === 'pro' ? 'var(--primary)' : 'var(--muted-foreground)';
+                const deploysPerSeatPerYear = 250;
+                const minsSavedPerDeploy = 12;
+                const hourlyRate = 75;
+                const rollbacksPerYear = seats;
+                const hoursPerRollback = 3;
+                const hoursRecovered = Math.round(seats * deploysPerSeatPerYear * (minsSavedPerDeploy / 60));
+                const deployValueDollars = Math.round(hoursRecovered * hourlyRate);
+                const rollbackValueDollars = Math.round(rollbacksPerYear * hoursPerRollback * hourlyRate);
+                const totalValue = deployValueDollars + rollbackValueDollars;
+                const roi = annualCost > 0 ? Math.round(totalValue / annualCost) : 0;
+                const metrics = [
+                  {
+                    label: 'Engineering hours recovered / yr',
+                    value: `${hoursRecovered.toLocaleString()} hrs`,
+                    sub: `${seats} seats × 250 deploys × 12 min saved`,
+                  },
+                  {
+                    label: 'Value of time recovered / yr',
+                    value: `$${totalValue.toLocaleString()}`,
+                    sub: 'Deploy wait + rollback incidents at $75/hr',
+                  },
+                  {
+                    label: 'Return on investment',
+                    value: `${roi}×`,
+                    sub: `$${totalValue.toLocaleString()} value vs $${annualCost.toLocaleString()} annual cost`,
+                  },
+                ];
+                return (
+                  <div
+                    style={{
+                      marginTop: 28,
+                      borderTop: `1px solid color-mix(in oklch, ${acColor} 15%, transparent)`,
+                      paddingTop: 24,
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: 11,
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.8px',
+                        color: 'var(--muted-foreground)',
+                        marginBottom: 14,
+                      }}
+                    >
+                      What this saves your team — based on {seats} seats
+                    </div>
+                    <div
+                      className="stats-grid"
+                      style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 12 }}
+                    >
+                      {metrics.map(({ label, value, sub }) => (
+                        <div
+                          key={label}
+                          style={{
+                            background: `color-mix(in oklch, ${acColor} 6%, transparent)`,
+                            border: `1px solid color-mix(in oklch, ${acColor} 15%, transparent)`,
+                            borderRadius: 10,
+                            padding: '16px 18px',
+                          }}
+                        >
+                          <div
+                            style={{ fontSize: 11, color: 'var(--muted-foreground)', marginBottom: 6, lineHeight: 1.4 }}
+                          >
+                            {label}
+                          </div>
+                          <div
+                            style={{
+                              fontSize: 26,
+                              fontWeight: 600,
+                              letterSpacing: '-1px',
+                              color: acColor,
+                              lineHeight: 1,
+                            }}
+                          >
+                            {value}
+                          </div>
+                          <div
+                            style={{ fontSize: 10, color: 'var(--muted-foreground)', marginTop: 6, lineHeight: 1.4 }}
+                          >
+                            {sub}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                    <div style={{ fontSize: 10, color: 'var(--muted-foreground)', marginTop: 10, lineHeight: 1.5 }}>
+                      * Conservative model: 1 deploy/engineer/day, 12 min saved per deploy, $75/hr blended rate, 1
+                      rollback incident/seat/yr at 3 hrs each. Drag the slider to see your numbers.
+                    </div>
+                  </div>
+                );
+              })()}
             </div>
           </div>
         </div>

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1,5 +1,7 @@
+import sgwsLogo from '@/images/companies/sgws.webp';
 import { cn } from '@/lib/utils';
 import { createFileRoute } from '@tanstack/react-router';
+import { Check, ChevronDown } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 
 export const Route = createFileRoute('/pricing')({
@@ -144,78 +146,15 @@ function PricingPage() {
   ];
 
   return (
-    <div style={{ background: C.black, color: C.white, lineHeight: 1.6 }}>
+    <div style={{ background: 'var(--background)', color: 'var(--foreground)', lineHeight: 1.6 }}>
       {/* ── HERO ── */}
-      <section style={{ textAlign: 'center', padding: '40px 40px 20px', maxWidth: 760, margin: '0 auto' }}>
-        <div
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 8,
-            background: C.purpleDim,
-            border: '1px solid rgba(139,92,246,0.3)',
-            color: C.purpleLight,
-            fontSize: 11,
-            fontWeight: 700,
-            textTransform: 'uppercase',
-            letterSpacing: '1.2px',
-            padding: '5px 14px',
-            borderRadius: 20,
-            marginBottom: 14,
-          }}
-        >
-          ● Pricing
-        </div>
-        <h1
-          style={{
-            fontSize: 'clamp(26px, 4vw, 40px)',
-            fontWeight: 900,
-            letterSpacing: '-1.5px',
-            lineHeight: 1.08,
-            marginBottom: 10,
-          }}
-        >
-          Pricing that scales with your team
-        </h1>
-        <p style={{ fontSize: 14, color: C.gray, maxWidth: 520, margin: '0 auto 0', lineHeight: 1.65 }}>
-          Start free and scale as you grow.
-        </p>
+      <section style={{ textAlign: 'center', padding: '64px 40px 20px', maxWidth: 760, margin: '0 auto' }}>
+        <h1 className="text-5xl font-medium leading-tighter mb-4 text-white">Pricing that scales with your team</h1>
+        <p className="text-xl text-muted-foreground">Start for free and scale as you grow.</p>
       </section>
 
-      {/* ── FEATURE BAR ── */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-evenly',
-          flexWrap: 'nowrap',
-          background: 'linear-gradient(135deg, #1A0F3A 0%, #0F0F1A 100%)',
-          borderTop: `1px solid rgba(139,92,246,0.2)`,
-          borderBottom: `1px solid rgba(139,92,246,0.2)`,
-          padding: '16px 40px',
-          width: '100%',
-        }}
-      >
-        {(
-          [
-            { icon: '∞', label: 'No build minutes' },
-            { icon: '⚡', label: 'Sub-second deployments' },
-            { icon: '☁', label: 'Bring Your Own Cloud (BYOC)' },
-            { icon: '✦', label: 'Unlimited preview environments' },
-          ] as { icon: string; label: string }[]
-        ).map(({ icon, label }) => (
-          <span
-            key={label}
-            style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: C.gray, whiteSpace: 'nowrap' }}
-          >
-            <span style={{ color: C.purpleLight, fontSize: 15 }}>{icon}</span>
-            {label}
-          </span>
-        ))}
-      </div>
-
       {/* ── PATH SELECTOR ── */}
-      <div style={{ textAlign: 'center', padding: '20px 40px', maxWidth: 760, margin: '0 auto' }}>
+      <div style={{ display: 'none' }}>
         {/* Path selector */}
         <div style={{ display: 'flex', gap: 14, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 16 }}>
           {(
@@ -236,13 +175,13 @@ function PricingPage() {
           ).map(({ id, icon, title, sub }) => {
             const active = path === id;
             const isMf = id === 'mf';
-            const activeColor = isMf ? C.purple : C.green;
+            const activeColor = isMf ? 'var(--primary)' : C.green;
             return (
               <button
                 key={id}
                 onClick={() => selectPath(id)}
                 style={{
-                  background: active ? (isMf ? 'rgba(139,92,246,0.12)' : 'rgba(16,185,129,0.1)') : C.black2,
+                  background: active ? (isMf ? 'rgba(139,92,246,0.12)' : 'rgba(16,185,129,0.1)') : 'var(--card)',
                   borderRadius: 12,
                   padding: '22px 28px',
                   cursor: 'pointer',
@@ -252,13 +191,13 @@ function PricingPage() {
                   position: 'relative',
                   overflow: 'hidden',
                   transition: 'all 0.25s',
-                  border: `2px solid ${active ? activeColor : C.border}`,
+                  border: `2px solid ${active ? activeColor : 'var(--border)'}`,
                   boxShadow: active
                     ? `0 0 0 1px ${activeColor}, 0 8px 32px ${isMf ? 'rgba(139,92,246,0.2)' : 'rgba(16,185,129,0.15)'}`
                     : 'none',
                   transform: active ? 'translateY(-2px)' : 'none',
                   fontFamily: 'inherit',
-                  color: C.white,
+                  color: 'var(--foreground)',
                 }}
               >
                 {active && (
@@ -276,7 +215,7 @@ function PricingPage() {
                       alignItems: 'center',
                       justifyContent: 'center',
                       fontSize: 11,
-                      fontWeight: 900,
+                      fontWeight: 600,
                     }}
                   >
                     ✓
@@ -284,28 +223,34 @@ function PricingPage() {
                 )}
                 <div style={{ fontSize: 22, marginBottom: 10 }}>{icon}</div>
                 <div
-                  style={{ fontSize: 15, fontWeight: 800, color: C.white, marginBottom: 5, letterSpacing: '-0.3px' }}
+                  style={{
+                    fontSize: 15,
+                    fontWeight: 600,
+                    color: 'var(--foreground)',
+                    marginBottom: 5,
+                    letterSpacing: '-0.3px',
+                  }}
                 >
                   {title}
                 </div>
-                <div style={{ fontSize: 12, color: C.gray, lineHeight: 1.5 }}>{sub}</div>
+                <div style={{ fontSize: 12, color: 'var(--muted-foreground)', lineHeight: 1.5 }}>{sub}</div>
               </button>
             );
           })}
         </div>
         {!path && (
-          <p style={{ fontSize: 12, color: C.grayDark }}>
+          <p style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
             Select your situation to see what matters most to your team.
           </p>
         )}
       </div>
 
       {/* ── VALUE PANELS ── */}
-      <div ref={panelsRef}>
+      <div ref={panelsRef} style={{ display: 'none' }}>
         {(['mf', 'nonmf'] as const).map((panelId) => {
           const isMf = panelId === 'mf';
           const visible = path === panelId;
-          const accent = isMf ? C.purpleLight : C.green;
+          const accent = isMf ? 'var(--primary-muted)' : C.green;
           const pains = isMf
             ? [
                 {
@@ -376,7 +321,7 @@ function PricingPage() {
                   <div
                     style={{
                       fontSize: 10,
-                      fontWeight: 700,
+                      fontWeight: 600,
                       textTransform: 'uppercase',
                       letterSpacing: '1.2px',
                       color: accent,
@@ -386,7 +331,13 @@ function PricingPage() {
                     {isMf ? 'For Module Federation teams' : 'For teams not yet on Module Federation'}
                   </div>
                   <h2
-                    style={{ fontSize: 26, fontWeight: 900, letterSpacing: '-0.6px', lineHeight: 1.2, color: C.white }}
+                    style={{
+                      fontSize: 26,
+                      fontWeight: 600,
+                      letterSpacing: '-0.6px',
+                      lineHeight: 1.2,
+                      color: 'var(--foreground)',
+                    }}
                   >
                     {isMf ? (
                       <>
@@ -415,7 +366,7 @@ function PricingPage() {
                       <div
                         style={{
                           fontSize: 11,
-                          color: C.grayDark,
+                          color: 'var(--muted-foreground)',
                           marginBottom: 6,
                           fontWeight: 600,
                           textTransform: 'uppercase',
@@ -424,11 +375,13 @@ function PricingPage() {
                       >
                         The problem
                       </div>
-                      <p style={{ fontSize: 13, color: C.gray, lineHeight: 1.5, marginBottom: 10 }}>{item.problem}</p>
+                      <p style={{ fontSize: 13, color: 'var(--muted-foreground)', lineHeight: 1.5, marginBottom: 10 }}>
+                        {item.problem}
+                      </p>
                       <div
                         style={{
                           fontSize: 12,
-                          fontWeight: 700,
+                          fontWeight: 600,
                           color: accent,
                           display: 'flex',
                           alignItems: 'center',
@@ -454,8 +407,8 @@ function PricingPage() {
             display: 'inline-flex',
             alignItems: 'center',
             gap: 4,
-            background: C.black3,
-            border: `1px solid ${C.border}`,
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
             borderRadius: 40,
             padding: 4,
           }}
@@ -465,12 +418,12 @@ function PricingPage() {
               key={mode}
               onClick={() => setBilling(mode)}
               style={{
-                background: billing === mode ? C.purple : 'none',
+                background: billing === mode ? 'var(--primary)' : 'none',
                 border: 'none',
-                color: billing === mode ? 'white' : C.gray,
+                color: billing === mode ? 'var(--primary-foreground)' : 'var(--muted-foreground)',
                 fontSize: 13,
                 fontWeight: 600,
-                padding: '7px 18px',
+                padding: '8px 16px',
                 borderRadius: 30,
                 cursor: 'pointer',
                 transition: 'all 0.2s',
@@ -486,11 +439,9 @@ function PricingPage() {
                   style={{
                     background: C.greenDim,
                     color: C.green,
-                    fontSize: 10,
-                    fontWeight: 700,
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px',
-                    padding: '2px 7px',
+                    fontSize: 12,
+                    fontWeight: 500,
+                    padding: '2px 8px',
                     borderRadius: 8,
                   }}
                 >
@@ -507,530 +458,581 @@ function PricingPage() {
         <div className="tier-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 14 }}>
           {/* FREE */}
           <div style={card()}>
-            <div style={{ minHeight: 220 }}>
-              <TierName>Free</TierName>
-              <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2, visibility: 'hidden' }}>
-                starting at
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <TierName>Free</TierName>
+                <p style={{ fontSize: 14, color: 'var(--muted-foreground)', lineHeight: 1.5 }}>1 seat</p>
               </div>
-              <div style={amt()}>$0</div>
-              <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>forever</div>
-              <TierSeats>1 seat · no credit card required</TierSeats>
+              <div>
+                <div style={{ fontSize: 12, color: 'transparent', marginBottom: 4, userSelect: 'none' }}>
+                  starting at
+                </div>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
+                  <span style={{ fontSize: 22, fontWeight: 600, color: 'var(--foreground)', lineHeight: 1 }}>$</span>
+                  <span
+                    style={{
+                      fontSize: 36,
+                      fontWeight: 600,
+                      color: 'var(--foreground)',
+                      letterSpacing: '-1px',
+                      lineHeight: 1,
+                    }}
+                  >
+                    0
+                  </span>
+                  <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 6, fontWeight: 400 }}>
+                    / seat / mo
+                  </span>
+                </div>
+              </div>
+              <Cta href="https://app.zephyr-cloud.io/" v="secondary">
+                Get started free
+              </Cta>
             </div>
-            <Cta href="https://app.zephyr-cloud.io/" v="secondary">
-              Get started free
-            </Cta>
-            <ul style={featList()}>
-              {[
-                'BYOC — bring your own cloud',
-                '1 cloud integration',
-                'All 15 bundler plugins',
-                'Basic version history',
-                'Tag / branch env creation',
-                '120GB bandwidth · 50GB storage',
-              ].map((f) => (
-                <Fi key={f} c="green">
-                  {f}
-                </Fi>
-              ))}
-            </ul>
+            <div style={{ height: 1, background: 'var(--accent)' }} />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <ul style={featList()}>
+                {[
+                  'BYOC — bring your own cloud',
+                  '1 cloud integration',
+                  'All 15 bundler plugins',
+                  'Basic version history',
+                  'Tag / branch env creation',
+                  '120GB bandwidth · 50GB storage',
+                ].map((f) => (
+                  <Fi key={f} c="green">
+                    {f}
+                  </Fi>
+                ))}
+              </ul>
+            </div>
           </div>
 
-          {/* PRO */}
+          {/* TEAMS */}
           <div
             style={{
               ...card(),
-              background: 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)',
-              border: `1px solid ${C.purple}`,
-              boxShadow: '0 0 48px rgba(139,92,246,0.12)',
+              background: 'linear-gradient(193.6deg, var(--card) 0%, rgba(124,58,237,0.35) 100%)',
+              border: '2px solid var(--primary)',
             }}
           >
-            <div
-              style={{
-                position: 'absolute',
-                top: -12,
-                left: '50%',
-                transform: 'translateX(-50%)',
-                background: C.purple,
-                color: 'white',
-                fontSize: 10,
-                fontWeight: 700,
-                textTransform: 'uppercase',
-                letterSpacing: '0.8px',
-                padding: '4px 14px',
-                borderRadius: 10,
-                whiteSpace: 'nowrap',
-              }}
-            >
-              Most Popular
-            </div>
-            <div style={{ minHeight: 220 }}>
-              <TierName purple>Teams</TierName>
-              <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
-              <div style={amt()}>{isAnnual ? fmt(Math.round(PRO_INTRO * ANNUAL_DISC)) : fmt(PRO_INTRO)}</div>
-              <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>
-                per seat / month ·{' '}
-                <a href="#calc" style={{ color: C.purpleLight, textDecoration: 'none', fontWeight: 600 }}>
-                  calculator ↓
-                </a>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4, position: 'relative' }}>
+                <TierName>Teams</TierName>
+                <p style={{ fontSize: 14, color: 'var(--muted-foreground)', lineHeight: 1.5 }}>2 – 75 seats</p>
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    right: 0,
+                    background: 'var(--primary)',
+                    color: 'var(--primary-foreground)',
+                    fontSize: 11,
+                    fontWeight: 600,
+                    padding: '3px 10px',
+                    borderRadius: 6,
+                  }}
+                >
+                  Popular
+                </div>
               </div>
-              <TierSeats>2 – 75 seats · costs decrease as your team scales</TierSeats>
+              <div>
+                <div style={{ fontSize: 12, color: 'var(--muted-foreground)', marginBottom: 4 }}>starting at</div>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
+                  <span style={{ fontSize: 22, fontWeight: 600, color: 'var(--foreground)', lineHeight: 1 }}>$</span>
+                  <span
+                    style={{
+                      fontSize: 36,
+                      fontWeight: 600,
+                      color: 'var(--foreground)',
+                      letterSpacing: '-1px',
+                      lineHeight: 1,
+                    }}
+                  >
+                    {isAnnual ? Math.round(PRO_INTRO * ANNUAL_DISC) : PRO_INTRO}
+                  </span>
+                  <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 6, fontWeight: 400 }}>
+                    / seat / mo
+                  </span>
+                </div>
+              </div>
+              <Cta href="https://app.zephyr-cloud.io/" v="primary">
+                Start free 30-day trial
+              </Cta>
             </div>
-            <Cta href="https://app.zephyr-cloud.io/" v="primary">
-              Start free 30-day trial
-            </Cta>
-            <ul style={featList()}>
-              <Fi c="green">
-                <strong style={{ color: C.white }}>BYOC</strong> — all cloud integrations
-              </Fi>
-              <Fi c="green">Instant rollbacks</Fi>
-              <Fi c="green">Full version history</Fi>
-              <Divider />
-              <Fi c="purple" dim={path === 'nonmf'}>
-                <strong style={{ color: C.white }}>Environment Overrides</strong> <MfTag />
-              </Fi>
-              <Fi c="purple">
-                <strong style={{ color: C.white }}>Env Variables</strong> — no redeploy
-              </Fi>
-              <Fi c="purple" dim={path === 'nonmf'}>
-                <strong style={{ color: C.white }}>Zephyr DevTools</strong> <MfTag />
-              </Fi>
-              <Fi c="purple" dim={path === 'nonmf'}>
-                <strong style={{ color: C.white }}>UML architecture map</strong> <MfTag />
-              </Fi>
-              <Fi c="purple" dim={path === 'nonmf'}>
-                <strong style={{ color: C.white }}>zephyr.dependencies</strong> <MfTag />
-              </Fi>
-              <Divider />
-              <Fi c="green">Per-team deploy permissions</Fi>
-              <Fi c="green">30-day audit logs</Fi>
-              <Fi c="green">Up to 75 collaborators</Fi>
-            </ul>
+            <div style={{ height: 1, background: 'var(--accent)' }} />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <ul style={featList()}>
+                <Fi c="green">
+                  <strong style={{ color: 'var(--foreground)' }}>BYOC</strong> — all cloud integrations
+                </Fi>
+                <Fi c="green">Instant rollbacks</Fi>
+                <Fi c="green">Full version history</Fi>
+                <Fi c="purple" dim={path === 'nonmf'} mf>
+                  <strong style={{ color: 'var(--foreground)' }}>Environment Overrides</strong>
+                </Fi>
+                <Fi c="purple">
+                  <strong style={{ color: 'var(--foreground)' }}>Env Variables</strong> — no redeploy
+                </Fi>
+                <Fi c="purple" dim={path === 'nonmf'} mf>
+                  <strong style={{ color: 'var(--foreground)' }}>Zephyr DevTools</strong>
+                </Fi>
+                <Fi c="purple" dim={path === 'nonmf'} mf>
+                  <strong style={{ color: 'var(--foreground)' }}>UML architecture map</strong>
+                </Fi>
+                <Fi c="purple" dim={path === 'nonmf'} mf>
+                  <strong style={{ color: 'var(--foreground)' }}>zephyr.dependencies</strong>
+                </Fi>
+                <Fi c="green">Per-team deploy permissions</Fi>
+                <Fi c="green">30-day audit logs</Fi>
+                <Fi c="green">Up to 75 collaborators</Fi>
+              </ul>
+            </div>
           </div>
 
           {/* BUSINESS */}
           <div
             style={{
               ...card(),
-              background: 'linear-gradient(160deg,#2A1F08 0%,#0F0F1A 60%)',
-              border: `1px solid ${C.amber}`,
-              boxShadow: '0 0 48px rgba(232,168,48,0.1)',
+              border: '1px solid var(--border)',
             }}
           >
-            <div
-              style={{
-                position: 'absolute',
-                top: -12,
-                left: '50%',
-                transform: 'translateX(-50%)',
-                background: C.amber,
-                color: '#0A0A0F',
-                fontSize: 10,
-                fontWeight: 700,
-                textTransform: 'uppercase',
-                letterSpacing: '0.8px',
-                padding: '4px 14px',
-                borderRadius: 10,
-                whiteSpace: 'nowrap',
-              }}
-            >
-              For Growing Teams
-            </div>
-            <div style={{ minHeight: 220 }}>
-              <TierName amber>Business</TierName>
-              <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
-              <div style={amt()}>{isAnnual ? fmt(Math.round(BIZ_INTRO * ANNUAL_DISC)) : fmt(BIZ_INTRO)}</div>
-              <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>
-                per seat / month ·{' '}
-                <a
-                  href="#calc"
-                  onClick={() => setCalcTab('biz')}
-                  style={{ color: C.amber, textDecoration: 'none', fontWeight: 600 }}
-                >
-                  calculator ↓
-                </a>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <TierName>Business</TierName>
+                <p style={{ fontSize: 14, color: 'var(--muted-foreground)', lineHeight: 1.5 }}>2 – 200 seats</p>
               </div>
-              <TierSeats>2 – 200 seats · SSO, SLAs, and governance included</TierSeats>
+              <div>
+                <div style={{ fontSize: 12, color: 'var(--muted-foreground)', marginBottom: 4 }}>starting at</div>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
+                  <span style={{ fontSize: 22, fontWeight: 600, color: 'var(--foreground)', lineHeight: 1 }}>$</span>
+                  <span
+                    style={{
+                      fontSize: 36,
+                      fontWeight: 600,
+                      color: 'var(--foreground)',
+                      letterSpacing: '-1px',
+                      lineHeight: 1,
+                    }}
+                  >
+                    {isAnnual ? Math.round(BIZ_INTRO * ANNUAL_DISC) : BIZ_INTRO}
+                  </span>
+                  <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 6, fontWeight: 400 }}>
+                    / seat / mo
+                  </span>
+                </div>
+              </div>
+              <Cta href="https://app.zephyr-cloud.io/" v="secondary">
+                Start free 30-day trial
+              </Cta>
             </div>
-            <Cta href="https://app.zephyr-cloud.io/" v="amber">
-              Start free 30-day trial
-            </Cta>
-            <ul style={featList()}>
-              <Fi c="amber">
-                <strong style={{ color: C.white }}>Everything in Teams</strong>
-              </Fi>
-              <Divider />
-              <Fi c="amber">SSO / SAML</Fi>
-              <Fi c="amber">Advanced roles &amp; permissions</Fi>
-              <Fi c="amber">Deployment approval workflows</Fi>
-              <Fi c="amber">Webhook integrations</Fi>
-              <Fi c="amber">90-day audit logs</Fi>
-              <Fi c="amber">99.9% uptime SLA</Fi>
-              <Fi c="amber">Priority support</Fi>
-              <Fi c="amber">Up to 200 collaborators</Fi>
-            </ul>
+            <div style={{ height: 1, background: 'var(--accent)' }} />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <ul style={featList()}>
+                <li style={{ fontSize: 14, color: 'var(--muted-foreground)', listStyle: 'none' }}>
+                  Everything in Teams, plus:
+                </li>
+                <Fi c="amber">SSO / SAML</Fi>
+                <Fi c="amber">Advanced roles &amp; permissions</Fi>
+                <Fi c="amber">Deployment approval workflows</Fi>
+                <Fi c="amber">Webhook integrations</Fi>
+                <Fi c="amber">90-day audit logs</Fi>
+                <Fi c="amber">99.9% uptime SLA</Fi>
+                <Fi c="amber">Priority support</Fi>
+                <Fi c="amber">Up to 200 collaborators</Fi>
+              </ul>
+            </div>
           </div>
 
           {/* ENTERPRISE */}
           <div style={card()}>
-            <div style={{ minHeight: 220 }}>
-              <TierName>Enterprise</TierName>
-              <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2, visibility: 'hidden' }}>
-                starting at
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <TierName>Enterprise</TierName>
+                <p style={{ fontSize: 14, color: 'var(--muted-foreground)', lineHeight: 1.5 }}>200+ seats</p>
               </div>
-              <div style={amt()}>Custom</div>
-              <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>&nbsp;</div>
-              <TierSeats>200+ seats · no RFP required · quote same day</TierSeats>
+              <div>
+                <div style={{ fontSize: 12, color: 'transparent', marginBottom: 4, userSelect: 'none' }}>
+                  starting at
+                </div>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
+                  <span
+                    style={{
+                      fontSize: 36,
+                      fontWeight: 600,
+                      color: 'var(--foreground)',
+                      letterSpacing: '-1px',
+                      lineHeight: 1,
+                    }}
+                  >
+                    Custom
+                  </span>
+                  <span style={{ fontSize: 14, color: 'transparent', marginLeft: 6, fontWeight: 400 }}>
+                    / seat / mo
+                  </span>
+                </div>
+              </div>
+              <Cta href="mailto:inbound@zephyr-cloud.io?subject=Enterprise" v="secondary">
+                Talk to sales
+              </Cta>
             </div>
-            <Cta href="mailto:inbound@zephyr-cloud.io?subject=Enterprise" v="secondary">
-              Talk to sales
-            </Cta>
-            <ul style={featList()}>
-              <Fi c="green">
-                <strong style={{ color: C.white }}>Everything in Business</strong>
-              </Fi>
-              <Divider />
-              {[
-                'SOC 2 Type II compliance',
-                'Data Processing Agreement',
-                'Dedicated CSM',
-                'Custom SLA (99.99%)',
-                'Negotiated contracts',
-                'Invoice / PO billing',
-                'White-glove onboarding',
-                'Custom bandwidth / storage',
-                'Unlimited collaborators',
-              ].map((f) => (
-                <Fi key={f} c="green">
-                  {f}
-                </Fi>
-              ))}
-            </ul>
+            <div style={{ height: 1, background: 'var(--accent)' }} />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <ul style={featList()}>
+                <li style={{ fontSize: 14, color: 'var(--muted-foreground)', listStyle: 'none' }}>
+                  Everything in Business, plus:
+                </li>
+                {[
+                  'SOC 2 Type II compliance',
+                  'Data Processing Agreement',
+                  'Dedicated CSM',
+                  'Custom SLA (99.99%)',
+                  'Negotiated contracts',
+                  'Invoice / PO billing',
+                  'White-glove onboarding',
+                  'Custom bandwidth / storage',
+                  'Unlimited collaborators',
+                ].map((f) => (
+                  <Fi key={f} c="green">
+                    {f}
+                  </Fi>
+                ))}
+              </ul>
+            </div>
           </div>
         </div>
       </section>
 
-      {/* ── ROI BANNER ── */}
-      <div style={{ maxWidth: 1160, margin: '-56px auto 72px', padding: '0 24px', textAlign: 'center' }}>
-        <div
-          style={{
-            background: C.black3,
-            border: `1px solid ${C.border}`,
-            borderRadius: 10,
-            padding: '14px 24px',
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 10,
-          }}
-        >
-          <span style={{ fontSize: 16, fontWeight: 900, color: C.purpleLight }}>1.5 sprints/quarter</span>
-          <span style={{ fontSize: 13, color: C.gray }}>
-            recovered by teams replacing internal MF tooling with Zephyr — based on customer data.
-          </span>
-        </div>
-      </div>
-
       {/* ── CALCULATOR ── */}
       <div id="calc" style={{ maxWidth: 960, margin: '0 auto 72px', padding: '0 24px' }}>
-        {/* Tab switcher */}
+        {/* Single outer border wraps tabs + body — no double borders */}
         <div
           style={{
-            display: 'flex',
-            borderRadius: '14px 14px 0 0',
+            border: `1px solid ${calcTab === 'pro' ? 'var(--primary)' : 'rgba(255,255,255,0.18)'}`,
+            borderRadius: 14,
             overflow: 'hidden',
-            border: `1px solid ${calcTab === 'pro' ? C.purple : C.amber}`,
-            borderBottom: 'none',
+            transition: 'border-color 0.3s',
           }}
         >
-          {(
-            [
-              {
-                id: 'pro',
-                label: 'Teams Calculator',
-                color: C.purple,
-                activeBg: 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)',
-              },
-              {
-                id: 'biz',
-                label: 'Business Calculator',
-                color: C.amber,
-                activeBg: 'linear-gradient(160deg,#2A1F08 0%,#0F0F1A 60%)',
-              },
-            ] as const
-          ).map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setCalcTab(tab.id)}
-              style={{
-                flex: 1,
-                padding: '12px 20px',
-                background: calcTab === tab.id ? tab.activeBg : C.black3,
-                border: 'none',
-                color: calcTab === tab.id ? tab.color : C.grayDark,
-                fontSize: 13,
-                fontWeight: 700,
-                cursor: 'pointer',
-                fontFamily: 'inherit',
-                transition: 'all 0.2s',
-                letterSpacing: '0.3px',
-              }}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </div>
-
-        {/* Calc body */}
-        <div
-          style={{
-            background:
-              calcTab === 'pro'
-                ? 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)'
-                : 'linear-gradient(160deg,#2A1F08 0%,#0F0F1A 60%)',
-            border: `1px solid ${calcTab === 'pro' ? C.purple : C.amber}`,
-            borderRadius: '0 0 14px 14px',
-            padding: '40px 48px',
-            transition: 'background 0.3s, border-color 0.3s',
-          }}
-        >
+          {/* Tab switcher */}
           <div
-            className="calc-header"
             style={{
               display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-              marginBottom: 32,
-              gap: 24,
-              flexWrap: 'wrap',
+              borderBottom: `1px solid ${calcTab === 'pro' ? 'var(--primary)' : 'rgba(255,255,255,0.18)'}`,
+              transition: 'border-color 0.3s',
             }}
           >
-            <div>
-              <h3 style={{ fontSize: 18, fontWeight: 900, letterSpacing: '-0.4px', color: C.white, marginBottom: 6 }}>
-                {calcTab === 'pro' ? 'Teams' : 'Business'} — see your exact price
-              </h3>
-              <p style={{ fontSize: 13, color: C.gray, maxWidth: 400, lineHeight: 1.6 }}>
-                The more seats you add, the less you pay per seat. Click a tier or drag the slider.
-              </p>
-            </div>
-            <div style={{ textAlign: 'right', flexShrink: 0 }}>
-              <div
+            {(
+              [
+                {
+                  id: 'pro',
+                  label: 'Teams Calculator',
+                  color: 'var(--foreground)' as string,
+                  activeBg: 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)',
+                },
+                {
+                  id: 'biz',
+                  label: 'Business Calculator',
+                  color: 'var(--foreground)' as string,
+                  activeBg: 'var(--card)',
+                },
+              ] as const
+            ).map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setCalcTab(tab.id)}
                 style={{
-                  fontSize: 11,
-                  fontWeight: 700,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.8px',
-                  color: calcTab === 'pro' ? C.purpleLight : C.amber,
-                  marginBottom: 4,
+                  flex: 1,
+                  padding: '8px 16px',
+                  background: calcTab === tab.id ? tab.activeBg : 'var(--card)',
+                  border: 'none',
+                  color: calcTab === tab.id ? tab.color : 'var(--muted-foreground)',
+                  fontSize: 14,
+                  fontWeight: 500,
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  transition: 'all 0.2s',
+                  letterSpacing: '0.3px',
                 }}
               >
-                {isAnnual ? 'Effective per month (annual)' : 'Total per month'}
-              </div>
-              <div style={{ fontSize: 42, fontWeight: 900, letterSpacing: '-1.5px', color: C.white, lineHeight: 1 }}>
-                {fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}
-              </div>
-              <div style={{ fontSize: 12, color: C.gray, marginTop: 4 }}>
-                {isAnnual
-                  ? `Billed as ${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr · you save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`
-                  : `${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr with annual — save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`}
-              </div>
-            </div>
+                {tab.label}
+              </button>
+            ))}
           </div>
 
-          {/* Slider */}
-          <div style={{ marginBottom: 28 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-              <span style={{ fontSize: 12, color: C.grayDark, fontWeight: 500 }}>Seats</span>
-              <strong style={{ fontSize: 14, color: C.white, fontWeight: 800 }}>
-                {calcTab === 'pro' ? proSeats : bizSeats} seats
-              </strong>
-            </div>
-            <input
-              type="range"
-              min={2}
-              max={calcTab === 'pro' ? 75 : 200}
-              value={calcTab === 'pro' ? proSeats : bizSeats}
-              onChange={(e) =>
-                calcTab === 'pro' ? setProSeats(parseInt(e.target.value)) : setBizSeats(parseInt(e.target.value))
-              }
-              className={calcTab === 'pro' ? 'pricing-slider' : 'pricing-slider-biz'}
-              style={{
-                width: '100%',
-                height: 5,
-                borderRadius: 3,
-                outline: 'none',
-                WebkitAppearance: 'none',
-                cursor: 'pointer',
-                background: `linear-gradient(to right,${calcTab === 'pro' ? C.purple : C.amber} 0%,${calcTab === 'pro' ? C.purple : C.amber} ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,${C.borderLight} ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,${C.borderLight} 100%)`,
-              }}
-            />
-          </div>
-
-          {/* Band cards */}
+          {/* Calc body */}
           <div
-            className="band-grid"
-            style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, marginBottom: 24 }}
+            style={{
+              background: calcTab === 'pro' ? 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)' : 'var(--card)',
+              padding: '40px 48px',
+              transition: 'background 0.3s',
+            }}
           >
-            {(calcTab === 'pro' ? PRO_BANDS : BIZ_BANDS).map((band, i) => {
-              const acColor = calcTab === 'pro' ? C.purple : C.amber;
-              const introRate = calcTab === 'pro' ? PRO_INTRO : BIZ_INTRO;
-              const dr = isAnnual ? Math.round(band.rate * ANNUAL_DISC) : band.rate;
-              const saving = Math.round((1 - band.rate / introRate) * 100);
-              const active = calcTab === 'pro' ? proBandIdx === i : bizBandIdx === i;
-              const rgbActive = calcTab === 'pro' ? '139,92,246' : '232,168,48';
-              return (
-                <div
-                  key={i}
-                  onClick={() => (calcTab === 'pro' ? setProSeats(band.midpoint) : setBizSeats(band.midpoint))}
+            <div
+              className="calc-header"
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'flex-start',
+                marginBottom: 32,
+                gap: 24,
+                flexWrap: 'wrap',
+              }}
+            >
+              <div>
+                <h3
                   style={{
-                    background: active ? `rgba(${rgbActive},0.15)` : 'rgba(255,255,255,0.04)',
-                    border: `1px solid ${active ? acColor : 'rgba(255,255,255,0.06)'}`,
-                    boxShadow: active ? `0 0 16px rgba(${rgbActive},0.1)` : 'none',
-                    borderRadius: 8,
-                    padding: '14px 12px',
-                    textAlign: 'center',
-                    transition: 'all 0.25s',
-                    cursor: 'pointer',
+                    fontSize: 18,
+                    fontWeight: 600,
+                    letterSpacing: '-0.4px',
+                    color: 'var(--foreground)',
+                    marginBottom: 6,
                   }}
                 >
-                  <div
-                    style={{
-                      fontSize: 10,
-                      fontWeight: 700,
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.5px',
-                      color: active ? acColor : C.grayDark,
-                      marginBottom: 6,
-                    }}
-                  >
-                    {band.label}
-                  </div>
-                  <div
-                    style={{
-                      fontSize: 22,
-                      fontWeight: 900,
-                      letterSpacing: '-0.8px',
-                      color: C.white,
-                      lineHeight: 1,
-                      marginBottom: 3,
-                    }}
-                  >
-                    {fmt(dr)}
-                  </div>
-                  <div style={{ fontSize: 10, color: C.grayDark }}>per seat / {isAnnual ? 'mo (annual)' : 'mo'}</div>
-                  <div style={{ fontSize: 10, fontWeight: 700, color: C.green, marginTop: 5, minHeight: 14 }}>
-                    {saving === 0 ? 'introductory rate' : `${saving}% less than intro`}
-                  </div>
+                  {calcTab === 'pro' ? 'Teams' : 'Business'} — see your exact price
+                </h3>
+                <p style={{ fontSize: 13, color: 'var(--muted-foreground)', maxWidth: 400, lineHeight: 1.6 }}>
+                  The more seats you add, the less you pay per seat. Click a tier or drag the slider.
+                </p>
+              </div>
+              <div style={{ textAlign: 'right', flexShrink: 0 }}>
+                <div
+                  style={{
+                    fontSize: 11,
+                    fontWeight: 600,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.8px',
+                    color: calcTab === 'pro' ? 'var(--primary-muted)' : 'var(--muted-foreground)',
+                    marginBottom: 4,
+                  }}
+                >
+                  {isAnnual ? 'Effective per month (annual)' : 'Total per month'}
                 </div>
-              );
-            })}
-          </div>
+                <div
+                  style={{
+                    fontSize: 42,
+                    fontWeight: 600,
+                    letterSpacing: '-1.5px',
+                    color: 'var(--foreground)',
+                    lineHeight: 1,
+                  }}
+                >
+                  {fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}
+                </div>
+                <div style={{ fontSize: 12, color: 'var(--muted-foreground)', marginTop: 4 }}>
+                  {isAnnual
+                    ? `Billed as ${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr · you save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`
+                    : `${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr with annual — save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`}
+                </div>
+              </div>
+            </div>
 
-          {/* Meta row */}
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              paddingTop: 20,
-              borderTop: '1px solid rgba(255,255,255,0.07)',
-              flexWrap: 'wrap',
-              gap: 12,
-            }}
-          >
-            <div style={{ fontSize: 12, color: C.gray }}>
-              Per seat:{' '}
-              <strong style={{ color: C.white }}>
-                {fmt(calcTab === 'pro' ? proEffRate : bizEffRate)}
-                {isAnnual ? ` (was ${fmt(calcTab === 'pro' ? proRate : bizRate)})` : ''}
-              </strong>
-            </div>
-            <div style={{ fontSize: 12, color: C.gray }}>
-              Monthly: <strong style={{ color: C.white }}>{fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}</strong>
-            </div>
-            <div style={{ fontSize: 12, color: C.gray }}>
-              Annual: <strong style={{ color: C.white }}>{fmt(calcTab === 'pro' ? proYearly : bizYearly)}</strong>
-              <span
+            {/* Slider */}
+            <div style={{ marginBottom: 28 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+                <span style={{ fontSize: 12, color: 'var(--muted-foreground)', fontWeight: 500 }}>Seats</span>
+                <strong style={{ fontSize: 14, color: 'var(--foreground)', fontWeight: 600 }}>
+                  {calcTab === 'pro' ? proSeats : bizSeats} seats
+                </strong>
+              </div>
+              <input
+                type="range"
+                min={2}
+                max={calcTab === 'pro' ? 75 : 200}
+                value={calcTab === 'pro' ? proSeats : bizSeats}
+                onChange={(e) =>
+                  calcTab === 'pro' ? setProSeats(parseInt(e.target.value)) : setBizSeats(parseInt(e.target.value))
+                }
+                className={calcTab === 'pro' ? 'pricing-slider' : 'pricing-slider-biz'}
                 style={{
-                  display: 'inline-block',
-                  background: C.greenDim,
-                  color: C.green,
-                  fontSize: 11,
-                  fontWeight: 700,
-                  padding: '2px 8px',
-                  borderRadius: 6,
-                  marginLeft: 6,
+                  width: '100%',
+                  height: 5,
+                  borderRadius: 3,
+                  outline: 'none',
+                  WebkitAppearance: 'none',
+                  cursor: 'pointer',
+                  background: `linear-gradient(to right,${calcTab === 'pro' ? 'var(--primary)' : 'var(--foreground)'} 0%,${calcTab === 'pro' ? 'var(--primary)' : 'var(--foreground)'} ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,var(--input) ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,var(--input) 100%)`,
                 }}
-              >
-                Save {fmt(calcTab === 'pro' ? proSave : bizSave)}
-              </span>
+              />
             </div>
-            <div style={{ fontSize: 12, color: C.gray }}>
-              {calcTab === 'pro' ? (
-                <>
-                  Need governance or SSO?{' '}
-                  <button
-                    onClick={() => setCalcTab('biz')}
+
+            {/* Band cards */}
+            <div
+              className="band-grid"
+              style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, marginBottom: 24 }}
+            >
+              {(calcTab === 'pro' ? PRO_BANDS : BIZ_BANDS).map((band, i) => {
+                const acColor = calcTab === 'pro' ? 'var(--primary)' : 'var(--muted-foreground)';
+                const introRate = calcTab === 'pro' ? PRO_INTRO : BIZ_INTRO;
+                const dr = isAnnual ? Math.round(band.rate * ANNUAL_DISC) : band.rate;
+                const saving = Math.round((1 - band.rate / introRate) * 100);
+                const active = calcTab === 'pro' ? proBandIdx === i : bizBandIdx === i;
+                const rgbActive = calcTab === 'pro' ? '139,92,246' : '115,115,115';
+                return (
+                  <div
+                    key={i}
+                    onClick={() => (calcTab === 'pro' ? setProSeats(band.midpoint) : setBizSeats(band.midpoint))}
                     style={{
-                      background: 'none',
-                      border: 'none',
-                      color: C.purpleLight,
-                      fontWeight: 700,
+                      background: active ? `rgba(${rgbActive},0.15)` : 'rgba(255,255,255,0.04)',
+                      border: `1px solid ${active ? acColor : 'rgba(255,255,255,0.06)'}`,
+                      boxShadow: active ? `0 0 16px rgba(${rgbActive},0.1)` : 'none',
+                      borderRadius: 8,
+                      padding: '14px 12px',
+                      textAlign: 'center',
+                      transition: 'all 0.25s',
                       cursor: 'pointer',
-                      fontSize: 12,
-                      fontFamily: 'inherit',
-                      padding: 0,
                     }}
                   >
-                    See Business pricing ↑
-                  </button>
-                </>
-              ) : (
-                <>
-                  Need 200+ seats?{' '}
-                  <a
-                    href="mailto:inbound@zephyr-cloud.io?subject=Enterprise"
-                    style={{ color: C.amber, textDecoration: 'none', fontWeight: 700 }}
-                  >
-                    Talk to sales
-                  </a>{' '}
-                  — quoted same day.
-                </>
-              )}
+                    <div
+                      style={{
+                        fontSize: 10,
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                        color: active ? 'var(--foreground)' : 'var(--muted-foreground)',
+                        marginBottom: 6,
+                      }}
+                    >
+                      {band.label}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: 22,
+                        fontWeight: 600,
+                        letterSpacing: '-0.8px',
+                        color: 'var(--foreground)',
+                        lineHeight: 1,
+                        marginBottom: 3,
+                      }}
+                    >
+                      {fmt(dr)}
+                    </div>
+                    <div style={{ fontSize: 10, color: 'var(--muted-foreground)' }}>
+                      per seat / {isAnnual ? 'mo (annual)' : 'mo'}
+                    </div>
+                    <div style={{ fontSize: 10, fontWeight: 500, color: C.green, marginTop: 5, minHeight: 14 }}>
+                      {saving === 0 ? 'introductory rate' : `${saving}% less than intro`}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
-          </div>
 
-          {/* Checkout CTA */}
-          <div style={{ marginTop: 24, display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
-            <a
-              href="https://app.zephyr-cloud.io/"
-              target="_blank"
-              rel="noopener"
+            {/* Meta row */}
+            <div
               style={{
-                display: 'inline-flex',
+                display: 'flex',
+                justifyContent: 'space-between',
                 alignItems: 'center',
-                gap: 10,
-                padding: '13px 28px',
-                borderRadius: 8,
-                fontWeight: 700,
-                fontSize: 14,
-                textDecoration: 'none',
-                transition: 'all 0.2s',
-                background: calcTab === 'pro' ? C.purple : C.amber,
-                color: calcTab === 'pro' ? 'white' : '#0A0A0F',
+                paddingTop: 20,
+                borderTop: '1px solid rgba(255,255,255,0.07)',
+                flexWrap: 'wrap',
+                gap: 12,
               }}
             >
-              Get started — {calcTab === 'pro' ? proSeats : bizSeats} seats ·{' '}
-              {fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}/mo
-            </a>
-            <span style={{ fontSize: 12, color: C.grayDark }}>No credit card required · free 30-day trial</span>
+              <div style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
+                Per seat:{' '}
+                <strong style={{ color: 'var(--foreground)' }}>
+                  {fmt(calcTab === 'pro' ? proEffRate : bizEffRate)}
+                  {isAnnual ? ` (was ${fmt(calcTab === 'pro' ? proRate : bizRate)})` : ''}
+                </strong>
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
+                Monthly:{' '}
+                <strong style={{ color: 'var(--foreground)' }}>
+                  {fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}
+                </strong>
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
+                Annual:{' '}
+                <strong style={{ color: 'var(--foreground)' }}>{fmt(calcTab === 'pro' ? proYearly : bizYearly)}</strong>
+                <span
+                  style={{
+                    display: 'inline-block',
+                    background: C.greenDim,
+                    color: C.green,
+                    fontSize: 12,
+                    fontWeight: 500,
+                    padding: '2px 8px',
+                    borderRadius: 8,
+                    marginLeft: 6,
+                  }}
+                >
+                  Save {fmt(calcTab === 'pro' ? proSave : bizSave)}
+                </span>
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
+                {calcTab === 'pro' ? (
+                  <>
+                    Need governance or SSO?{' '}
+                    <button
+                      onClick={() => setCalcTab('biz')}
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        color: 'var(--primary-muted)',
+                        fontWeight: 600,
+                        cursor: 'pointer',
+                        fontSize: 12,
+                        fontFamily: 'inherit',
+                        padding: 0,
+                      }}
+                    >
+                      See Business pricing ↑
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    Need 200+ seats?{' '}
+                    <a
+                      href="mailto:inbound@zephyr-cloud.io?subject=Enterprise"
+                      style={{ color: 'var(--foreground)', textDecoration: 'none', fontWeight: 600 }}
+                    >
+                      Talk to sales
+                    </a>{' '}
+                    — quoted same day.
+                  </>
+                )}
+              </div>
+            </div>
+
+            {/* Checkout CTA */}
+            <div style={{ marginTop: 24, display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
+              <a
+                href="https://app.zephyr-cloud.io/"
+                target="_blank"
+                rel="noopener"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  padding: '8px 16px',
+                  borderRadius: 8,
+                  fontWeight: 500,
+                  fontSize: 14,
+                  textDecoration: 'none',
+                  transition: 'all 0.2s',
+                  background: calcTab === 'pro' ? 'var(--primary)' : 'var(--secondary)',
+                  color: calcTab === 'pro' ? 'var(--primary-foreground)' : 'var(--secondary-foreground)',
+                }}
+              >
+                Get started — {calcTab === 'pro' ? proSeats : bizSeats} seats ·{' '}
+                {fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}/mo
+              </a>
+              <span style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
+                No credit card required · free 30-day trial
+              </span>
+            </div>
           </div>
         </div>
+        {/* end outer border wrapper */}
       </div>
 
       {/* ── PROOF BAR ── */}
       <div
         style={{
-          borderTop: `1px solid ${C.border}`,
-          borderBottom: `1px solid ${C.border}`,
+          borderTop: '1px solid var(--border)',
+          borderBottom: '1px solid var(--border)',
           padding: '20px 40px',
           display: 'flex',
           justifyContent: 'center',
@@ -1047,11 +1049,19 @@ function PricingPage() {
           { n: 'SOC', s: ' 2', l: 'Compliant' },
         ].map((s) => (
           <div key={s.l} style={{ textAlign: 'center' }}>
-            <div style={{ fontSize: 22, fontWeight: 900, letterSpacing: '-0.8px', color: C.white, lineHeight: 1 }}>
+            <div
+              style={{
+                fontSize: 22,
+                fontWeight: 600,
+                letterSpacing: '-0.8px',
+                color: 'var(--foreground)',
+                lineHeight: 1,
+              }}
+            >
               {s.n}
-              <span style={{ color: C.purpleLight }}>{s.s}</span>
+              <span style={{ color: 'var(--primary-muted)' }}>{s.s}</span>
             </div>
-            <div style={{ fontSize: 11, color: C.grayDark, marginTop: 3 }}>{s.l}</div>
+            <div style={{ fontSize: 11, color: 'var(--muted-foreground)', marginTop: 3 }}>{s.l}</div>
           </div>
         ))}
       </div>
@@ -1060,10 +1070,10 @@ function PricingPage() {
       <section style={{ maxWidth: 960, margin: '0 auto 80px', padding: '0 24px' }}>
         <div
           style={{
-            background: C.black2,
-            border: `1px solid ${C.border}`,
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
             borderRadius: 12,
-            padding: '32px 40px',
+            padding: '28px 40px',
             display: 'grid',
             gridTemplateColumns: '1fr auto',
             gap: 32,
@@ -1072,77 +1082,105 @@ function PricingPage() {
           }}
         >
           <div>
-            <p style={{ fontSize: 16, fontWeight: 600, color: C.white, lineHeight: 1.6, fontStyle: 'italic' }}>
-              <span style={{ color: C.purpleLight, fontSize: 24, lineHeight: 0, verticalAlign: -6, marginRight: 4 }}>
+            <p
+              style={{
+                fontSize: 16,
+                fontWeight: 600,
+                color: 'var(--foreground)',
+                lineHeight: 1.6,
+                fontStyle: 'italic',
+              }}
+            >
+              <span
+                style={{
+                  color: 'var(--primary-muted)',
+                  fontSize: 24,
+                  lineHeight: 0,
+                  verticalAlign: -6,
+                  marginRight: 4,
+                }}
+              >
                 "
               </span>
               Zephyr gave us the deployment orchestration layer we'd been trying to build internally for two years. We
               stopped writing tooling and started shipping product.
-              <span style={{ color: C.purpleLight, fontSize: 24, lineHeight: 0, verticalAlign: -6, marginLeft: 4 }}>
+              <span
+                style={{ color: 'var(--primary-muted)', fontSize: 24, lineHeight: 0, verticalAlign: -6, marginLeft: 4 }}
+              >
                 "
               </span>
             </p>
-            <p style={{ fontSize: 12, color: C.grayDark, marginTop: 10 }}>
+            <p style={{ fontSize: 12, color: 'var(--muted-foreground)', marginTop: 10 }}>
               Engineering leadership ·{' '}
-              <strong style={{ color: C.gray, fontWeight: 600 }}>Southern Glazer's Wine &amp; Spirits</strong>
+              <strong style={{ color: 'var(--foreground)', fontWeight: 600 }}>
+                Southern Glazer's Wine &amp; Spirits
+              </strong>
             </p>
           </div>
           <div
             style={{
               textAlign: 'right',
-              fontSize: 11,
-              fontWeight: 700,
-              textTransform: 'uppercase',
-              letterSpacing: '1px',
-              color: C.grayDark,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+              gap: 8,
               whiteSpace: 'nowrap',
             }}
           >
+            <img
+              src={sgwsLogo}
+              alt="Southern Glazer's Wine & Spirits"
+              style={{ height: 36, width: 'auto', opacity: 0.9 }}
+            />
             <span
               style={{
-                display: 'block',
-                fontSize: 18,
-                fontWeight: 900,
-                color: C.white,
-                letterSpacing: '-0.5px',
-                marginBottom: 4,
+                fontSize: 11,
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '1px',
+                color: 'var(--muted-foreground)',
               }}
             >
-              Southern
-              <br />
-              Glazer's
+              Enterprise customer
             </span>
-            Enterprise customer
           </div>
         </div>
         <div
           className="stats-grid"
           style={{
-            background: C.black2,
-            border: `1px solid ${C.border}`,
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
             borderRadius: 12,
             padding: '28px 40px',
             display: 'grid',
             gridTemplateColumns: '1fr 1fr',
           }}
         >
-          <div style={{ paddingRight: 32, borderRight: `1px solid ${C.border}` }}>
+          <div style={{ paddingRight: 32, borderRight: '1px solid var(--border)' }}>
             <div
               style={{
                 fontSize: 11,
-                fontWeight: 700,
+                fontWeight: 600,
                 textTransform: 'uppercase',
                 letterSpacing: '0.8px',
-                color: C.purpleLight,
+                color: 'var(--muted-foreground)',
                 marginBottom: 8,
               }}
             >
               Teams using Zephyr report
             </div>
-            <div style={{ fontSize: 32, fontWeight: 900, letterSpacing: '-1px', color: C.white, lineHeight: 1 }}>
+            <div
+              style={{
+                fontSize: 32,
+                fontWeight: 600,
+                letterSpacing: '-1px',
+                color: 'var(--foreground)',
+                lineHeight: 1,
+              }}
+            >
               1.5 sprints
             </div>
-            <div style={{ fontSize: 13, color: C.gray, marginTop: 4 }}>
+            <div style={{ fontSize: 13, color: 'var(--muted-foreground)', marginTop: 4 }}>
               recovered per quarter by eliminating internal MF tooling
             </div>
           </div>
@@ -1150,19 +1188,27 @@ function PricingPage() {
             <div
               style={{
                 fontSize: 11,
-                fontWeight: 700,
+                fontWeight: 600,
                 textTransform: 'uppercase',
                 letterSpacing: '0.8px',
-                color: C.purpleLight,
+                color: 'var(--muted-foreground)',
                 marginBottom: 8,
               }}
             >
               Average time to first deploy
             </div>
-            <div style={{ fontSize: 32, fontWeight: 900, letterSpacing: '-1px', color: C.white, lineHeight: 1 }}>
+            <div
+              style={{
+                fontSize: 32,
+                fontWeight: 600,
+                letterSpacing: '-1px',
+                color: 'var(--foreground)',
+                lineHeight: 1,
+              }}
+            >
               &lt; 15 min
             </div>
-            <div style={{ fontSize: 13, color: C.gray, marginTop: 4 }}>
+            <div style={{ fontSize: 13, color: 'var(--muted-foreground)', marginTop: 4 }}>
               from signup to first cloud deployment — no infrastructure migration required
             </div>
           </div>
@@ -1171,37 +1217,43 @@ function PricingPage() {
 
       {/* ── FEATURE TABLE ── */}
       <section style={{ maxWidth: 1160, margin: '0 auto 80px', padding: '0 24px' }}>
-        <div style={{ textAlign: 'center', marginBottom: 36 }}>
-          <h2 style={{ fontSize: 28, fontWeight: 900, letterSpacing: '-0.6px', marginBottom: 8 }}>
+        <div style={{ marginBottom: 36 }}>
+          <h2 className="text-4xl font-normal text-[#faf5ff]" style={{ marginBottom: 8 }}>
             Everything in the platform
           </h2>
-          <p style={{ fontSize: 14, color: C.gray }}>Every feature, every tier.</p>
+          <p style={{ fontSize: 14, color: 'var(--muted-foreground)' }}>Every feature, every tier.</p>
         </div>
-        <div style={{ overflowX: 'auto' }}>
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, minWidth: 680 }}>
+        <div
+          style={{
+            overflowX: 'auto',
+            borderRadius: 16,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: '#0d0d0d',
+            boxShadow: '0 20px 60px rgba(0,0,0,0.28)',
+          }}
+        >
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14, minWidth: 680 }}>
             <thead>
-              <tr>
+              <tr style={{ background: 'black', borderBottom: '1px solid rgba(255,255,255,0.1)' }}>
                 {(
                   [
-                    ['Feature', 'left', C.grayDark, '28%'],
-                    ['Free', 'center', C.grayDark, undefined],
-                    ['Teams', 'center', C.purpleLight, undefined],
-                    ['Business', 'center', C.amber, undefined],
-                    ['Enterprise', 'center', C.grayDark, undefined],
-                  ] as [string, string, string, string | undefined][]
-                ).map(([label, align, color, w]) => (
+                    ['', 'left', '28%'],
+                    ['Free', 'center', undefined],
+                    ['Teams', 'center', undefined],
+                    ['Business', 'center', undefined],
+                    ['Enterprise', 'center', undefined],
+                  ] as [string, string, string | undefined][]
+                ).map(([label, align, w], i) => (
                   <th
-                    key={label}
+                    key={label || 'feature'}
                     style={{
-                      padding: '10px 16px',
-                      fontSize: 10,
-                      fontWeight: 700,
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.8px',
-                      color,
+                      padding: '20px',
+                      fontSize: 14,
+                      fontWeight: 500,
+                      color: 'var(--foreground)',
                       textAlign: align as 'left' | 'center',
-                      borderBottom: `1px solid ${C.border}`,
                       width: w,
+                      borderLeft: i > 0 ? '0.5px solid rgba(255,255,255,0.15)' : undefined,
                     }}
                   >
                     {label}
@@ -1260,51 +1312,42 @@ function PricingPage() {
                       <td
                         colSpan={5}
                         style={{
-                          background: C.black3,
-                          color: C.grayDark,
-                          fontSize: 10,
-                          fontWeight: 700,
-                          textTransform: 'uppercase',
-                          letterSpacing: '1px',
-                          padding: '8px 16px',
-                          borderTop: `1px solid ${C.border}`,
+                          background: 'rgba(255,255,255,0.05)',
+                          color: 'var(--foreground)',
+                          fontSize: 20,
+                          fontWeight: 500,
+                          padding: '16px 20px',
                         }}
                       >
-                        {row.g}
-                        {row.mfg && (
-                          <span style={{ marginLeft: 6 }}>
-                            <MfTag />
-                          </span>
-                        )}
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                          {row.g}
+                          {row.mfg && <MfTag />}
+                        </div>
                       </td>
                     </tr>
                   );
-                const cell = (val = '', hl?: 'pro' | 'biz') => {
+                const cell = (val = '') => {
                   const color =
                     val === '✓'
-                      ? C.green
+                      ? 'var(--foreground)'
                       : val === '—'
-                        ? C.borderLight
+                        ? 'var(--input)'
                         : val === 'Limited'
-                          ? C.grayDark
+                          ? 'var(--muted-foreground)'
                           : val === 'Custom' || val === 'Unlimited'
-                            ? C.purpleLight
-                            : C.gray;
+                            ? 'var(--primary-muted)'
+                            : 'var(--muted-foreground)';
                   return (
                     <td
                       style={{
-                        padding: '11px 16px',
-                        borderBottom: `1px solid ${C.border}`,
+                        padding: '16px 20px',
+                        borderTop: '0.5px solid rgba(255,255,255,0.15)',
+                        borderLeft: '0.5px solid rgba(255,255,255,0.15)',
                         textAlign: 'center',
                         color,
-                        background:
-                          hl === 'pro'
-                            ? 'rgba(139,92,246,0.04)'
-                            : hl === 'biz'
-                              ? 'rgba(232,168,48,0.04)'
-                              : 'transparent',
-                        fontSize: val === '✓' || val === '—' ? 14 : 11,
-                        fontWeight: val === 'Limited' || val === 'Custom' ? 700 : 400,
+                        minHeight: 60,
+                        fontSize: val === '✓' || val === '—' ? 15 : 13,
+                        fontWeight: val === 'Limited' || val === 'Custom' ? 600 : 400,
                       }}
                     >
                       {val}
@@ -1315,10 +1358,11 @@ function PricingPage() {
                   <tr key={i} className={cn(path === 'nonmf' && row.mf && 'opacity-40')}>
                     <td
                       style={{
-                        padding: '11px 16px',
-                        borderBottom: `1px solid ${C.border}`,
-                        color: C.white,
-                        fontWeight: 500,
+                        padding: '20px',
+                        borderTop: '0.5px solid rgba(255,255,255,0.15)',
+                        color: 'var(--foreground)',
+                        fontWeight: 400,
+                        fontSize: 14,
                       }}
                     >
                       {row.f}
@@ -1329,8 +1373,8 @@ function PricingPage() {
                       )}
                     </td>
                     {cell(row.fr)}
-                    {cell(row.pr, 'pro')}
-                    {cell(row.bz, 'biz')}
+                    {cell(row.pr)}
+                    {cell(row.bz)}
                     {cell(row.en)}
                   </tr>
                 );
@@ -1341,126 +1385,112 @@ function PricingPage() {
       </section>
 
       {/* ── FAQ ── */}
-      <section style={{ maxWidth: 680, margin: '0 auto 80px', padding: '0 24px' }}>
-        <div style={{ textAlign: 'center', marginBottom: 36 }}>
-          <h2 style={{ fontSize: 28, fontWeight: 900, letterSpacing: '-0.6px' }}>Common questions</h2>
+      <section
+        className="grid gap-8 pb-20 lg:grid-cols-[1fr_1fr]"
+        style={{ maxWidth: 1160, margin: '0 auto', padding: '0 24px 80px' }}
+      >
+        <div>
+          <h2 className="max-w-md text-4xl font-normal text-foreground">Common questions</h2>
         </div>
-        {faqs.map((faq, i) => (
-          <div key={i} style={{ borderBottom: `1px solid ${C.border}` }}>
-            <button
-              onClick={() => setOpenFaq(openFaq === i ? null : i)}
-              style={{
-                width: '100%',
-                background: 'none',
-                border: 'none',
-                color: C.white,
-                fontFamily: 'inherit',
-                fontSize: 14,
-                fontWeight: 600,
-                textAlign: 'left',
-                padding: '18px 0',
-                cursor: 'pointer',
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                gap: 16,
-              }}
-            >
-              {faq.q}
-              <span
-                style={{
-                  color: openFaq === i ? C.purpleLight : C.grayDark,
-                  fontSize: 18,
-                  flexShrink: 0,
-                  transition: 'transform 0.2s',
-                  display: 'inline-block',
-                  transform: openFaq === i ? 'rotate(45deg)' : 'none',
-                }}
-              >
-                +
-              </span>
-            </button>
-            {openFaq === i && (
-              <div style={{ fontSize: 13, color: C.gray, lineHeight: 1.75, paddingBottom: 18 }}>{faq.a}</div>
-            )}
-          </div>
-        ))}
+        <div className="space-y-2">
+          {faqs.map((faq, i) => {
+            const isOpen = openFaq === i;
+            return (
+              <div key={i} className="overflow-hidden rounded-[18px] border border-border bg-card">
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between gap-4 p-4 text-left text-base text-foreground"
+                  onClick={() => setOpenFaq(isOpen ? null : i)}
+                >
+                  <span>{faq.q}</span>
+                  <ChevronDown className={`h-5 w-5 shrink-0 transition duration-300 ${isOpen ? 'rotate-180' : ''}`} />
+                </button>
+                {isOpen && <p className="px-4 pb-4 text-[15px] leading-7 text-muted-foreground">{faq.a}</p>}
+              </div>
+            );
+          })}
+        </div>
       </section>
 
       {/* ── FINAL CTA ── */}
-      <section style={{ textAlign: 'center', padding: '80px 40px 100px', borderTop: `1px solid ${C.border}` }}>
-        <h2 style={{ fontSize: 40, fontWeight: 900, letterSpacing: '-1px', lineHeight: 1.1, marginBottom: 14 }}>
-          Start free.
-          <br />
-          <span style={{ color: C.purpleLight }}>No cliff. No lock-in.</span>
-        </h2>
-        <p style={{ fontSize: 16, color: C.gray, marginBottom: 32 }}>
-          One cloud integration free, forever. Upgrade when your team is ready.
-        </p>
-        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 24 }}>
-          <a
-            href="https://app.zephyr-cloud.io/"
-            target="_blank"
+      <section style={{ padding: '80px 24px 100px', borderTop: '1px solid var(--border)' }}>
+        <div style={{ maxWidth: 1160, margin: '0 auto' }}>
+          <div
+            className="cta-card"
             style={{
-              background: C.purple,
-              color: 'white',
-              fontSize: 14,
-              fontWeight: 700,
-              padding: '14px 32px',
-              borderRadius: 8,
-              textDecoration: 'none',
+              position: 'relative',
+              overflow: 'hidden',
+              background: 'var(--card)',
+              border: '1px solid rgba(255,255,255,0.12)',
+              borderRadius: 16,
+              padding: '56px 48px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 32,
             }}
           >
-            Start for free
-          </a>
-          <a
-            href="mailto:inbound@zephyr-cloud.io?subject=Sales"
-            target="_blank"
-            style={{
-              background: 'transparent',
-              border: `1px solid ${C.borderLight}`,
-              color: C.white,
-              fontSize: 14,
-              fontWeight: 600,
-              padding: '14px 32px',
-              borderRadius: 8,
-              textDecoration: 'none',
-            }}
-          >
-            Talk to sales
-          </a>
-        </div>
-        <div style={{ display: 'flex', gap: 20, justifyContent: 'center', flexWrap: 'wrap' }}>
-          {[
-            'No credit card required',
-            'Cancel anytime',
-            'BYOC — your data stays in your cloud',
-            'Invoice billing available',
-            'Export your data anytime',
-          ].map((t) => (
-            <span key={t} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: C.grayDark }}>
-              <span
+            {/* Purple gradient shader */}
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                background:
+                  'linear-gradient(to left, oklch(0.541 0.247 293) 0%, oklch(0.541 0.247 293 / 0.85) 15%, oklch(0.38 0.18 285 / 0.45) 38%, oklch(0.22 0.07 270 / 0.1) 58%, transparent 72%)',
+                pointerEvents: 'none',
+              }}
+            />
+            {/* Text */}
+            <div style={{ position: 'relative', minWidth: 0 }}>
+              <h2
                 style={{
-                  width: 5,
-                  height: 5,
-                  borderRadius: '50%',
-                  background: C.green,
-                  flexShrink: 0,
-                  display: 'inline-block',
+                  fontSize: 24,
+                  fontWeight: 500,
+                  color: 'var(--foreground)',
+                  lineHeight: '32px',
+                  marginBottom: 8,
                 }}
-              />
-              {t}
-            </span>
-          ))}
+              >
+                Start free. <span style={{ color: 'var(--primary-muted)' }}>No cliff. No lock-in.</span>
+              </h2>
+              <p style={{ fontSize: 16, fontWeight: 400, color: 'var(--muted-foreground)', lineHeight: 1.5 }}>
+                One cloud integration free, forever. Upgrade when your team is ready.
+              </p>
+            </div>
+            {/* Button */}
+            <a
+              href="https://app.zephyr-cloud.io/"
+              target="_blank"
+              rel="noopener"
+              style={{
+                position: 'relative',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                background: 'rgba(255,255,255,0.92)',
+                color: '#0A0A0F',
+                fontSize: 14,
+                fontWeight: 500,
+                padding: '8px 16px',
+                borderRadius: 8,
+                textDecoration: 'none',
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+                border: '1px solid rgba(255,255,255,0.2)',
+              }}
+            >
+              Get started
+            </a>
+          </div>
         </div>
       </section>
 
       {/* Slider + responsive styles */}
       <style>{`
-        .pricing-slider::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:${C.purple}; cursor:pointer; box-shadow:0 0 0 4px rgba(139,92,246,0.2); border:2px solid ${C.white}; }
-        .pricing-slider::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:${C.purple}; cursor:pointer; border:2px solid ${C.white}; }
-        .pricing-slider-biz::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:${C.amber}; cursor:pointer; box-shadow:0 0 0 4px rgba(232,168,48,0.2); border:2px solid ${C.white}; }
-        .pricing-slider-biz::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:${C.amber}; cursor:pointer; border:2px solid ${C.white}; }
+        .pricing-slider::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:var(--primary); cursor:pointer; box-shadow:0 0 0 4px rgba(139,92,246,0.2); border:2px solid var(--foreground); }
+        .pricing-slider::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:var(--primary); cursor:pointer; border:2px solid var(--foreground); }
+        .pricing-slider-biz::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:var(--foreground); cursor:pointer; box-shadow:0 0 0 4px rgba(255,255,255,0.1); border:2px solid var(--border); }
+        .pricing-slider-biz::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:var(--foreground); cursor:pointer; border:2px solid var(--border); }
         @media (max-width: 960px) {
           .tier-grid { grid-template-columns: repeat(2,1fr) !important; }
         }
@@ -1470,8 +1500,10 @@ function PricingPage() {
           .value-grid { grid-template-columns: 1fr !important; }
           .calc-header { flex-direction: column !important; }
           .stats-grid { grid-template-columns: 1fr !important; }
-          .stats-grid > div:first-child { padding-right: 0 !important; border-right: none !important; padding-bottom: 24px; border-bottom: 1px solid ${C.border}; }
+          .stats-grid > div:first-child { padding-right: 0 !important; border-right: none !important; padding-bottom: 24px; border-bottom: 1px solid var(--border); }
           .stats-grid > div:last-child { padding-left: 0 !important; padding-top: 24px; }
+          .cta-card { flex-direction: column !important; padding: 32px 24px !important; }
+          .cta-card > a { width: 100% !important; }
         }
       `}</style>
     </div>
@@ -1480,54 +1512,26 @@ function PricingPage() {
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 const card = () => ({
-  background: C.black2,
-  border: `1px solid ${C.border}`,
-  borderRadius: 14,
-  padding: '32px 28px',
+  background: 'var(--card)',
+  border: '1px solid var(--border)',
+  borderRadius: 16,
+  padding: '32px',
   position: 'relative' as const,
   display: 'flex',
   flexDirection: 'column' as const,
+  gap: 32,
 });
-const amt = () => ({ fontSize: 48, fontWeight: 900, letterSpacing: '-2px', color: C.white, lineHeight: 1 });
 const featList = () => ({
   listStyle: 'none' as const,
   display: 'flex' as const,
   flexDirection: 'column' as const,
-  gap: 10,
+  gap: 12,
   margin: 0,
   padding: 0,
 });
 
-function TierName({ children, purple, amber }: { children: ReactNode; purple?: boolean; amber?: boolean }) {
-  return (
-    <div
-      style={{
-        fontSize: 12,
-        fontWeight: 700,
-        textTransform: 'uppercase',
-        letterSpacing: '1px',
-        color: purple ? C.purpleLight : amber ? C.amber : C.grayDark,
-        marginBottom: 14,
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-function TierSeats({ children }: { children: ReactNode }) {
-  return (
-    <div
-      style={{
-        fontSize: 12,
-        color: C.grayDark,
-        paddingBottom: 18,
-        marginBottom: 18,
-        borderBottom: `1px solid ${C.border}`,
-      }}
-    >
-      {children}
-    </div>
-  );
+function TierName({ children }: { children: ReactNode }) {
+  return <div style={{ fontSize: 20, fontWeight: 600, color: 'var(--foreground)' }}>{children}</div>;
 }
 function Cta({
   href,
@@ -1537,7 +1541,7 @@ function Cta({
 }: {
   href: string;
   children: ReactNode;
-  v: 'primary' | 'secondary' | 'amber';
+  v: 'primary' | 'secondary';
   onClick?: () => void;
 }) {
   return (
@@ -1549,31 +1553,39 @@ function Cta({
         display: 'block',
         width: '100%',
         textAlign: 'center',
-        padding: '12px 20px',
+        padding: '8px 16px',
         borderRadius: 8,
         fontSize: 14,
-        fontWeight: 700,
+        fontWeight: 500,
         textDecoration: 'none',
         marginBottom: 24,
         transition: 'all 0.2s',
         ...(v === 'primary'
-          ? { background: C.purple, color: 'white' }
-          : v === 'amber'
-            ? { background: C.amber, color: '#0A0A0F' }
-            : { background: 'transparent', border: `1px solid ${C.borderLight}`, color: C.white }),
+          ? { background: 'var(--primary)', color: 'var(--primary-foreground)' }
+          : { background: 'var(--secondary)', color: 'var(--secondary-foreground)' }),
       }}
     >
       {children}
     </a>
   );
 }
-function Fi({ children, c, dim }: { children: ReactNode; c: 'green' | 'purple' | 'amber'; dim?: boolean }) {
-  const ic = c === 'green' ? C.green : c === 'purple' ? C.purpleLight : C.amber;
+function Fi({
+  children,
+  c,
+  dim,
+  mf,
+}: {
+  children: ReactNode;
+  c: 'green' | 'purple' | 'amber';
+  dim?: boolean;
+  mf?: boolean;
+}) {
+  const ic = 'var(--foreground)';
   return (
     <li
       style={{
-        fontSize: 13,
-        color: C.gray,
+        fontSize: 14,
+        color: 'var(--muted-foreground)',
         display: 'flex',
         alignItems: 'flex-start',
         gap: 9,
@@ -1581,24 +1593,29 @@ function Fi({ children, c, dim }: { children: ReactNode; c: 'green' | 'purple' |
         opacity: dim ? 0.4 : 1,
       }}
     >
-      <span style={{ color: ic, fontSize: 12, marginTop: 1, flexShrink: 0 }}>✓</span>
-      {children}
+      <Check size={16} style={{ color: ic, flexShrink: 0, marginTop: 1 }} />
+      <span style={{ flex: 1 }}>{children}</span>
+      {mf && (
+        <span style={{ flexShrink: 0, marginTop: 2 }}>
+          <MfTag />
+        </span>
+      )}
     </li>
   );
 }
 function Divider() {
-  return <li style={{ listStyle: 'none', height: 1, background: C.border, margin: '4px 0' }} />;
+  return <li style={{ listStyle: 'none', height: 1, background: 'var(--accent)', margin: '4px 0' }} />;
 }
 function MfTag() {
   return (
     <span
       style={{
         fontSize: 9,
-        fontWeight: 700,
+        fontWeight: 600,
         textTransform: 'uppercase',
         letterSpacing: '0.5px',
-        background: C.purpleDim,
-        color: C.purpleLight,
+        background: 'rgba(124,58,237,0.15)',
+        color: 'var(--primary-muted)',
         border: `1px solid rgba(139,92,246,0.3)`,
         padding: '1px 5px',
         borderRadius: 3,

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -177,9 +177,45 @@ function PricingPage() {
         >
           Pricing that scales with your team
         </h1>
-        <p style={{ fontSize: 14, color: C.gray, maxWidth: 520, margin: '0 auto 14px', lineHeight: 1.65 }}>
+        <p style={{ fontSize: 14, color: C.gray, maxWidth: 520, margin: '0 auto 0', lineHeight: 1.65 }}>
           Start free and scale as you grow.
         </p>
+      </section>
+
+      {/* ── FEATURE BAR ── */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-evenly',
+          flexWrap: 'nowrap',
+          background: 'linear-gradient(135deg, #1A0F3A 0%, #0F0F1A 100%)',
+          borderTop: `1px solid rgba(139,92,246,0.2)`,
+          borderBottom: `1px solid rgba(139,92,246,0.2)`,
+          padding: '16px 40px',
+          width: '100%',
+        }}
+      >
+        {(
+          [
+            { icon: '∞', label: 'No build minutes' },
+            { icon: '⚡', label: 'Sub-second deployments' },
+            { icon: '☁', label: 'Bring Your Own Cloud (BYOC)' },
+            { icon: '✦', label: 'Unlimited preview environments' },
+          ] as { icon: string; label: string }[]
+        ).map(({ icon, label }) => (
+          <span
+            key={label}
+            style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: C.gray, whiteSpace: 'nowrap' }}
+          >
+            <span style={{ color: C.purpleLight, fontSize: 15 }}>{icon}</span>
+            {label}
+          </span>
+        ))}
+      </div>
+
+      {/* ── PATH SELECTOR ── */}
+      <div style={{ textAlign: 'center', padding: '20px 40px', maxWidth: 760, margin: '0 auto' }}>
         {/* Path selector */}
         <div style={{ display: 'flex', gap: 14, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 16 }}>
           {(
@@ -262,39 +298,6 @@ function PricingPage() {
             Select your situation to see what matters most to your team.
           </p>
         )}
-      </section>
-
-      {/* ── FEATURE BAR ── */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-evenly',
-          flexWrap: 'nowrap',
-          background: 'linear-gradient(135deg, #1A0F3A 0%, #0F0F1A 100%)',
-          borderTop: `1px solid rgba(139,92,246,0.2)`,
-          borderBottom: `1px solid rgba(139,92,246,0.2)`,
-          padding: '16px 40px',
-          width: '100%',
-          marginBottom: 0,
-        }}
-      >
-        {(
-          [
-            { icon: '∞', label: 'No build minutes' },
-            { icon: '⚡', label: 'Sub-second deployments' },
-            { icon: '☁', label: 'Bring Your Own Cloud (BYOC)' },
-            { icon: '✦', label: 'Unlimited preview environments' },
-          ] as { icon: string; label: string }[]
-        ).map(({ icon, label }) => (
-          <span
-            key={label}
-            style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: C.gray, whiteSpace: 'nowrap' }}
-          >
-            <span style={{ color: C.purpleLight, fontSize: 15 }}>{icon}</span>
-            {label}
-          </span>
-        ))}
       </div>
 
       {/* ── VALUE PANELS ── */}

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -33,10 +33,10 @@ const PRO_BANDS = [
   { min: 51, max: 75, rate: 24, midpoint: 63, label: '51 – 75 seats' },
 ];
 const BIZ_BANDS = [
-  { min: 2, max: 25, rate: 52, midpoint: 14, label: '2 – 25 seats' },
-  { min: 26, max: 75, rate: 45, midpoint: 50, label: '26 – 75 seats' },
-  { min: 76, max: 150, rate: 38, midpoint: 113, label: '76 – 150 seats' },
-  { min: 151, max: 200, rate: 34, midpoint: 175, label: '151 – 200 seats' },
+  { min: 2, max: 25, rate: 99, midpoint: 14, label: '2 – 25 seats' },
+  { min: 26, max: 75, rate: 82, midpoint: 50, label: '26 – 75 seats' },
+  { min: 76, max: 150, rate: 69, midpoint: 113, label: '76 – 150 seats' },
+  { min: 151, max: 200, rate: 59, midpoint: 175, label: '151 – 200 seats' },
 ];
 const PRO_INTRO = PRO_BANDS[0].rate;
 const BIZ_INTRO = BIZ_BANDS[0].rate;
@@ -102,18 +102,18 @@ function PricingPage() {
   const faqs = [
     {
       q: 'Do I need Module Federation to get value from Zephyr?',
-      a: 'No. BYOC, instant rollbacks, and environment variables without redeploying are available on Pro — none of them require Module Federation. MF-native features are additive. Many teams start without MF and adopt it later.',
+      a: 'No. BYOC, instant rollbacks, and environment variables without redeploying are available on Teams — none of them require Module Federation. MF-native features are additive. Many teams start without MF and adopt it later.',
     },
     {
-      q: 'How does Pro pricing work?',
-      a: "Pro starts at $39/seat for 2–10 seats. At 11–25 seats the rate drops to $32/seat. At 26–50 it's $27/seat. At 51–75 it's $24/seat — 38% less than the intro rate. Use the calculator to see your exact price.",
+      q: 'How does Teams pricing work?',
+      a: "Teams starts at $39/seat for 2–10 seats. At 11–25 seats the rate drops to $32/seat. At 26–50 it's $27/seat. At 51–75 it's $24/seat — 38% less than the intro rate. Use the calculator to see your exact price.",
     },
     {
       q: 'How does Business pricing work?',
       a: 'Business starts at $52/seat for 2–25 seats, dropping to $45/seat at 26–75, $38/seat at 76–150, and $34/seat at 151–200. It includes everything in Pro plus SSO/SAML, advanced roles, approval workflows, webhook integrations, 90-day audit logs, and a 99.9% uptime SLA.',
     },
     {
-      q: 'When should I upgrade from Pro to Business?',
+      q: 'When should I upgrade from Teams to Business?',
       a: 'Upgrade to Business when you need SSO for your identity provider, SLA guarantees, advanced access controls, or 90-day audit retention. Most teams make the switch when IT or compliance asks for SSO, or when deployment approval workflows become a requirement.',
     },
     {
@@ -122,11 +122,11 @@ function PricingPage() {
     },
     {
       q: 'Are there overage charges for bandwidth or storage?',
-      a: "Pro includes 1.5TB bandwidth and 500GB storage. We'll reach out before charging anything — no automatic overage fees. Business and Enterprise limits are agreed upfront so procurement always knows the ceiling.",
+      a: "Teams includes 1.5TB bandwidth and 500GB storage. We'll reach out before charging anything — no automatic overage fees. Business and Enterprise limits are agreed upfront so procurement always knows the ceiling.",
     },
     {
       q: 'Can we pay by invoice or purchase order?',
-      a: "Yes. Business and Enterprise invoicing and PO billing are standard. Pro is credit card monthly or annually. If procurement requires an invoice for Pro, contact sales and we'll accommodate it.",
+      a: "Yes. Business and Enterprise invoicing and PO billing are standard. Teams is credit card monthly or annually. If procurement requires an invoice for Teams, contact sales and we'll accommodate it.",
     },
     {
       q: 'What makes the MF-native features different?',
@@ -138,7 +138,7 @@ function PricingPage() {
     },
     {
       q: 'Is there an annual discount?',
-      a: 'Yes — 15% off Pro and Business when billed annually. Toggle above to see annual pricing reflected live in the calculator.',
+      a: 'Yes — 15% off Teams and Business when billed annually. Toggle above to see annual pricing reflected live in the calculator.',
     },
   ];
 
@@ -560,7 +560,7 @@ function PricingPage() {
             >
               Most Popular
             </div>
-            <TierName purple>Pro</TierName>
+            <TierName purple>Teams</TierName>
             <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
             <div style={amt()}>{isAnnual ? fmt(Math.round(PRO_INTRO * ANNUAL_DISC)) : fmt(PRO_INTRO)}</div>
             <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>
@@ -681,7 +681,7 @@ function PricingPage() {
             </div>
             <ul style={featList()}>
               <Fi c="amber">
-                <strong style={{ color: C.white }}>Everything in Pro</strong>
+                <strong style={{ color: C.white }}>Everything in Teams</strong>
               </Fi>
               <Divider />
               <Fi c="amber">SSO / SAML</Fi>
@@ -769,7 +769,7 @@ function PricingPage() {
             [
               {
                 id: 'pro',
-                label: 'Pro Calculator',
+                label: 'Teams Calculator',
                 color: C.purple,
                 activeBg: 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)',
               },
@@ -829,7 +829,7 @@ function PricingPage() {
           >
             <div>
               <h3 style={{ fontSize: 18, fontWeight: 900, letterSpacing: '-0.4px', color: C.white, marginBottom: 6 }}>
-                {calcTab === 'pro' ? 'Pro' : 'Business'} — see your exact price
+                {calcTab === 'pro' ? 'Teams' : 'Business'} — see your exact price
               </h3>
               <p style={{ fontSize: 13, color: C.gray, maxWidth: 400, lineHeight: 1.6 }}>
                 The more seats you add, the less you pay per seat. Click a tier or drag the slider.
@@ -1183,7 +1183,7 @@ function PricingPage() {
                   [
                     ['Feature', 'left', C.grayDark, '28%'],
                     ['Free', 'center', C.grayDark, undefined],
-                    ['Pro', 'center', C.purpleLight, undefined],
+                    ['Teams', 'center', C.purpleLight, undefined],
                     ['Business', 'center', C.amber, undefined],
                     ['Enterprise', 'center', C.grayDark, undefined],
                   ] as [string, string, string, string | undefined][]

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -180,38 +180,43 @@ function PricingPage() {
         <p style={{ fontSize: 14, color: C.gray, maxWidth: 520, margin: '0 auto 14px', lineHeight: 1.65 }}>
           Start free and scale as you grow.
         </p>
-        <div style={{ display: 'flex', gap: 10, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 20 }}>
-          {[
-            'No build minutes',
-            'Sub-second deployments',
-            'Bring Your Own Cloud (BYOC)',
-            'Unlimited preview environments',
-          ].map((f) => (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            gap: 28,
+            marginBottom: 20,
+            background: 'linear-gradient(135deg, #1A0F3A 0%, #0F0F1A 100%)',
+            border: `1px solid rgba(139,92,246,0.25)`,
+            borderRadius: 12,
+            padding: '14px 32px',
+            maxWidth: 760,
+            margin: '0 auto 20px',
+          }}
+        >
+          {(
+            [
+              { icon: '∞', label: 'No build minutes' },
+              { icon: '⚡', label: 'Sub-second deployments' },
+              { icon: '☁', label: 'Bring Your Own Cloud (BYOC)' },
+              { icon: '✦', label: 'Unlimited preview environments' },
+            ] as { icon: string; label: string }[]
+          ).map(({ icon, label }) => (
             <span
-              key={f}
+              key={label}
               style={{
                 display: 'flex',
                 alignItems: 'center',
-                gap: 6,
-                fontSize: 12,
+                gap: 7,
+                fontSize: 13,
                 color: C.gray,
-                background: C.black2,
-                border: `1px solid ${C.border}`,
-                borderRadius: 20,
-                padding: '4px 12px',
+                whiteSpace: 'nowrap',
               }}
             >
-              <span
-                style={{
-                  width: 5,
-                  height: 5,
-                  borderRadius: '50%',
-                  background: C.green,
-                  flexShrink: 0,
-                  display: 'inline-block',
-                }}
-              />
-              {f}
+              <span style={{ color: C.purpleLight, fontSize: 15 }}>{icon}</span>
+              {label}
             </span>
           ))}
         </div>

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -78,7 +78,7 @@ function PricingPage() {
 
   function selectPath(p: 'mf' | 'nonmf') {
     setPath(p);
-    setTimeout(() => billingRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 500);
+    setTimeout(() => tiersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 300);
   }
 
   // Pro calc
@@ -145,7 +145,7 @@ function PricingPage() {
   return (
     <div style={{ background: C.black, color: C.white, lineHeight: 1.6 }}>
       {/* ── HERO ── */}
-      <section style={{ textAlign: 'center', padding: '72px 40px 48px', maxWidth: 760, margin: '0 auto' }}>
+      <section style={{ textAlign: 'center', padding: '40px 40px 20px', maxWidth: 760, margin: '0 auto' }}>
         <div
           style={{
             display: 'inline-flex',
@@ -160,64 +160,28 @@ function PricingPage() {
             letterSpacing: '1.2px',
             padding: '5px 14px',
             borderRadius: 20,
-            marginBottom: 24,
+            marginBottom: 14,
           }}
         >
           ● Pricing
         </div>
         <h1
           style={{
-            fontSize: 'clamp(32px, 5vw, 52px)',
+            fontSize: 'clamp(26px, 4vw, 40px)',
             fontWeight: 900,
             letterSpacing: '-1.5px',
             lineHeight: 1.08,
-            marginBottom: 18,
+            marginBottom: 10,
           }}
         >
           Pricing that scales
           <br />
           with your team. <em style={{ fontStyle: 'normal', color: C.purpleLight }}>Not against it.</em>
         </h1>
-        <p style={{ fontSize: 16, color: C.gray, maxWidth: 520, margin: '0 auto 32px', lineHeight: 1.75 }}>
+        <p style={{ fontSize: 14, color: C.gray, maxWidth: 520, margin: '0 auto 20px', lineHeight: 1.65 }}>
           Start free. The more your team grows, the less you pay per seat — and every tier is justified by what's
           included.
         </p>
-
-        {/* Above-fold CTA */}
-        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 48 }}>
-          <button
-            onClick={() => tiersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
-            style={{
-              background: C.purple,
-              color: 'white',
-              fontSize: 14,
-              fontWeight: 700,
-              padding: '13px 28px',
-              borderRadius: 8,
-              border: 'none',
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-            }}
-          >
-            Get Started
-          </button>
-          <a
-            href="mailto:inbound@zephyr-cloud.io?subject=Sales"
-            style={{
-              background: 'transparent',
-              border: `1px solid ${C.borderLight}`,
-              color: C.white,
-              fontSize: 14,
-              fontWeight: 600,
-              padding: '13px 28px',
-              borderRadius: 8,
-              textDecoration: 'none',
-              display: 'inline-block',
-            }}
-          >
-            Talk to sales
-          </a>
-        </div>
 
         {/* Path selector */}
         <div style={{ display: 'flex', gap: 14, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 16 }}>
@@ -447,7 +411,7 @@ function PricingPage() {
       })}
 
       {/* ── BILLING TOGGLE ── */}
-      <div ref={billingRef} style={{ textAlign: 'center', padding: '0 24px 48px' }}>
+      <div ref={billingRef} style={{ textAlign: 'center', padding: '0 24px 24px' }}>
         <div
           style={{
             display: 'inline-flex',

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1,12 +1,12 @@
 import { cn } from '@/lib/utils';
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 
 export const Route = createFileRoute('/pricing')({
   component: PricingPage,
 });
 
-// ── Design tokens ─────────────────────────────────────────────────────────────
+// ── Design tokens ──────────────────────────────────────────────────────────────
 const C = {
   black: '#0A0A0F',
   black2: '#0F0F1A',
@@ -22,35 +22,52 @@ const C = {
   green: '#10B981',
   greenDim: '#064E3B',
   amber: '#E8A830',
+  amberDim: '#2A1F08',
 } as const;
 
-// ── Pro calculator bands ──────────────────────────────────────────────────────
+// ── Volume bands ───────────────────────────────────────────────────────────────
 const PRO_BANDS = [
   { min: 2, max: 10, rate: 39, midpoint: 6, label: '2 – 10 seats' },
   { min: 11, max: 25, rate: 32, midpoint: 18, label: '11 – 25 seats' },
   { min: 26, max: 50, rate: 27, midpoint: 38, label: '26 – 50 seats' },
   { min: 51, max: 75, rate: 24, midpoint: 63, label: '51 – 75 seats' },
 ];
-const INTRO_RATE = PRO_BANDS[0].rate;
+const BIZ_BANDS = [
+  { min: 2, max: 25, rate: 52, midpoint: 14, label: '2 – 25 seats' },
+  { min: 26, max: 75, rate: 45, midpoint: 50, label: '26 – 75 seats' },
+  { min: 76, max: 150, rate: 38, midpoint: 113, label: '76 – 150 seats' },
+  { min: 151, max: 200, rate: 34, midpoint: 175, label: '151 – 200 seats' },
+];
+const PRO_INTRO = PRO_BANDS[0].rate;
+const BIZ_INTRO = BIZ_BANDS[0].rate;
 const ANNUAL_DISC = 0.85;
 
-function getRate(seats: number) {
-  return PRO_BANDS.find((b) => seats >= b.min && seats <= b.max)?.rate ?? 24;
+function getProRate(s: number) {
+  return PRO_BANDS.find((b) => s >= b.min && s <= b.max)?.rate ?? 24;
 }
-function getBandIdx(seats: number) {
-  return PRO_BANDS.findIndex((b) => seats >= b.min && seats <= b.max);
+function getBizRate(s: number) {
+  return BIZ_BANDS.find((b) => s >= b.min && s <= b.max)?.rate ?? 34;
+}
+function getProBandIdx(s: number) {
+  return PRO_BANDS.findIndex((b) => s >= b.min && s <= b.max);
+}
+function getBizBandIdx(s: number) {
+  return BIZ_BANDS.findIndex((b) => s >= b.min && s <= b.max);
 }
 function fmt(n: number) {
   return '$' + Math.round(n).toLocaleString('en-US');
 }
 
-// ── Page ──────────────────────────────────────────────────────────────────────
+// ── Page ───────────────────────────────────────────────────────────────────────
 function PricingPage() {
   const [billing, setBilling] = useState<'monthly' | 'annual'>('monthly');
   const [path, setPath] = useState<'mf' | 'nonmf' | null>(null);
-  const [seats, setSeats] = useState(2);
+  const [proSeats, setProSeats] = useState(6);
+  const [bizSeats, setBizSeats] = useState(14);
+  const [calcTab, setCalcTab] = useState<'pro' | 'biz'>('pro');
   const [openFaq, setOpenFaq] = useState<number | null>(null);
   const billingRef = useRef<HTMLDivElement>(null);
+  const tiersRef = useRef<HTMLElement>(null);
   const isAnnual = billing === 'annual';
 
   useEffect(() => {
@@ -61,18 +78,26 @@ function PricingPage() {
 
   function selectPath(p: 'mf' | 'nonmf') {
     setPath(p);
-    setTimeout(() => billingRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 400);
+    setTimeout(() => billingRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 500);
   }
 
-  // Calculator
-  const rate = getRate(seats);
-  const effRate = isAnnual ? Math.round(rate * ANNUAL_DISC * 100) / 100 : rate;
-  const moTotal = Math.round(seats * effRate);
-  const yrTotal = Math.round(seats * rate * 12 * ANNUAL_DISC);
-  const yrFull = seats * rate * 12;
-  const yrSave = Math.round(yrFull - yrTotal);
-  const bandIdx = getBandIdx(seats);
-  const sliderPct = ((seats - 2) / 73) * 100;
+  // Pro calc
+  const proRate = getProRate(proSeats);
+  const proEffRate = isAnnual ? Math.round(proRate * ANNUAL_DISC * 100) / 100 : proRate;
+  const proMonthly = Math.round(proSeats * proEffRate);
+  const proYearly = Math.round(proSeats * proRate * 12 * ANNUAL_DISC);
+  const proSave = Math.round(proSeats * proRate * 12 - proYearly);
+  const proBandIdx = getProBandIdx(proSeats);
+  const proSliderPct = ((proSeats - 2) / 73) * 100;
+
+  // Business calc
+  const bizRate = getBizRate(bizSeats);
+  const bizEffRate = isAnnual ? Math.round(bizRate * ANNUAL_DISC * 100) / 100 : bizRate;
+  const bizMonthly = Math.round(bizSeats * bizEffRate);
+  const bizYearly = Math.round(bizSeats * bizRate * 12 * ANNUAL_DISC);
+  const bizSave = Math.round(bizSeats * bizRate * 12 - bizYearly);
+  const bizBandIdx = getBizBandIdx(bizSeats);
+  const bizSliderPct = ((bizSeats - 2) / 198) * 100;
 
   const faqs = [
     {
@@ -80,24 +105,28 @@ function PricingPage() {
       a: 'No. BYOC, instant rollbacks, and environment variables without redeploying are available on Pro — none of them require Module Federation. MF-native features are additive. Many teams start without MF and adopt it later.',
     },
     {
-      q: 'How does Pro pricing work as the team grows?',
+      q: 'How does Pro pricing work?',
       a: "Pro starts at $39/seat for 2–10 seats. At 11–25 seats the rate drops to $32/seat. At 26–50 it's $27/seat. At 51–75 it's $24/seat — 38% less than the intro rate. Use the calculator to see your exact price.",
     },
     {
-      q: 'What happens when we hit 76 seats?',
-      a: 'You move to Enterprise — custom pricing, quoted same day, no RFP required. Enterprise is volume-based so the per-seat rate keeps decreasing. No cliff, no surprise.',
+      q: 'How does Business pricing work?',
+      a: 'Business starts at $52/seat for 2–25 seats, dropping to $45/seat at 26–75, $38/seat at 76–150, and $34/seat at 151–200. It includes everything in Pro plus SSO/SAML, advanced roles, approval workflows, webhook integrations, 90-day audit logs, and a 99.9% uptime SLA.',
+    },
+    {
+      q: 'When should I upgrade from Pro to Business?',
+      a: 'Upgrade to Business when you need SSO for your identity provider, SLA guarantees, advanced access controls, or 90-day audit retention. Most teams make the switch when IT or compliance asks for SSO, or when deployment approval workflows become a requirement.',
     },
     {
       q: 'What is BYOC — and what does it mean for our data?',
-      a: 'Bring Your Own Cloud. Deployments go to your own infrastructure — Cloudflare, AWS, Fastly, Akamai, or Vercel. Your data never leaves your cloud. This answers most data residency and DPA questions before your security team asks them.',
+      a: 'Bring Your Own Cloud. Deployments go to your own infrastructure — Cloudflare, AWS, Fastly, Akamai, or Vercel. Your data never leaves your cloud. BYOC is available on all plans including Free. This answers most data residency and DPA questions before your security team asks them.',
     },
     {
       q: 'Are there overage charges for bandwidth or storage?',
-      a: "Pro includes 1.5TB bandwidth and 500GB storage. We'll reach out before charging anything — no automatic overage fees. Enterprise limits are agreed upfront so procurement always knows the ceiling.",
+      a: "Pro includes 1.5TB bandwidth and 500GB storage. We'll reach out before charging anything — no automatic overage fees. Business and Enterprise limits are agreed upfront so procurement always knows the ceiling.",
     },
     {
       q: 'Can we pay by invoice or purchase order?',
-      a: "Yes. Enterprise invoicing and PO billing are standard. Pro is credit card monthly or annually. If procurement requires an invoice for Pro, contact sales and we'll accommodate it.",
+      a: "Yes. Business and Enterprise invoicing and PO billing are standard. Pro is credit card monthly or annually. If procurement requires an invoice for Pro, contact sales and we'll accommodate it.",
     },
     {
       q: 'What makes the MF-native features different?',
@@ -109,7 +138,7 @@ function PricingPage() {
     },
     {
       q: 'Is there an annual discount?',
-      a: 'Yes — 15% off Pro when billed annually. Toggle above to see annual pricing reflected live in the calculator.',
+      a: 'Yes — 15% off Pro and Business when billed annually. Toggle above to see annual pricing reflected live in the calculator.',
     },
   ];
 
@@ -145,14 +174,50 @@ function PricingPage() {
             marginBottom: 18,
           }}
         >
-          Deployment that fits
+          Pricing that scales
           <br />
-          where your team <em style={{ fontStyle: 'normal', color: C.purpleLight }}>actually is.</em>
+          with your team. <em style={{ fontStyle: 'normal', color: C.purpleLight }}>Not against it.</em>
         </h1>
-        <p style={{ fontSize: 16, color: C.gray, maxWidth: 520, margin: '0 auto 48px', lineHeight: 1.75 }}>
-          Whether you're running Module Federation or not, Zephyr meets you there — and the price goes down as your team
-          scales up.
+        <p style={{ fontSize: 16, color: C.gray, maxWidth: 520, margin: '0 auto 32px', lineHeight: 1.75 }}>
+          Start free. The more your team grows, the less you pay per seat — and every tier is justified by what's
+          included.
         </p>
+
+        {/* Above-fold CTA */}
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 48 }}>
+          <button
+            onClick={() => tiersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+            style={{
+              background: C.purple,
+              color: 'white',
+              fontSize: 14,
+              fontWeight: 700,
+              padding: '13px 28px',
+              borderRadius: 8,
+              border: 'none',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+          >
+            Get Started
+          </button>
+          <a
+            href="mailto:inbound@zephyr-cloud.io?subject=Sales"
+            style={{
+              background: 'transparent',
+              border: `1px solid ${C.borderLight}`,
+              color: C.white,
+              fontSize: 14,
+              fontWeight: 600,
+              padding: '13px 28px',
+              borderRadius: 8,
+              textDecoration: 'none',
+              display: 'inline-block',
+            }}
+          >
+            Talk to sales
+          </a>
+        </div>
 
         {/* Path selector */}
         <div style={{ display: 'flex', gap: 14, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 16 }}>
@@ -162,7 +227,7 @@ function PricingPage() {
                 id: 'mf',
                 icon: '⚡',
                 title: 'We use Module Federation',
-                sub: "We're running MF and need a proper deployment platform built around it.",
+                sub: "We're running MF and need a deployment platform built around it.",
               },
               {
                 id: 'nonmf',
@@ -176,11 +241,11 @@ function PricingPage() {
             const isMf = id === 'mf';
             const activeColor = isMf ? C.purple : C.green;
             return (
-              <div
+              <button
                 key={id}
                 onClick={() => selectPath(id)}
                 style={{
-                  background: C.black2,
+                  background: active ? (isMf ? 'rgba(139,92,246,0.12)' : 'rgba(16,185,129,0.1)') : C.black2,
                   borderRadius: 12,
                   padding: '22px 28px',
                   cursor: 'pointer',
@@ -192,9 +257,11 @@ function PricingPage() {
                   transition: 'all 0.25s',
                   border: `2px solid ${active ? activeColor : C.border}`,
                   boxShadow: active
-                    ? `0 0 0 1px ${activeColor}, 0 8px 32px ${isMf ? 'rgba(139,92,246,0.15)' : 'rgba(16,185,129,0.12)'}`
+                    ? `0 0 0 1px ${activeColor}, 0 8px 32px ${isMf ? 'rgba(139,92,246,0.2)' : 'rgba(16,185,129,0.15)'}`
                     : 'none',
                   transform: active ? 'translateY(-2px)' : 'none',
+                  fontFamily: 'inherit',
+                  color: C.white,
                 }}
               >
                 {active && (
@@ -203,15 +270,15 @@ function PricingPage() {
                       position: 'absolute',
                       top: 14,
                       right: 14,
-                      width: 20,
-                      height: 20,
+                      width: 22,
+                      height: 22,
                       borderRadius: '50%',
                       background: activeColor,
                       color: 'white',
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',
-                      fontSize: 10,
+                      fontSize: 11,
                       fontWeight: 900,
                     }}
                   >
@@ -225,7 +292,7 @@ function PricingPage() {
                   {title}
                 </div>
                 <div style={{ fontSize: 12, color: C.gray, lineHeight: 1.5 }}>{sub}</div>
-              </div>
+              </button>
             );
           })}
         </div>
@@ -334,7 +401,7 @@ function PricingPage() {
                   )}
                 </h2>
               </div>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
+              <div className="value-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
                 {pains.map((item, i) => (
                   <div
                     key={i}
@@ -435,8 +502,8 @@ function PricingPage() {
       </div>
 
       {/* ── TIER CARDS ── */}
-      <section style={{ maxWidth: 960, margin: '0 auto', padding: '0 24px 80px' }}>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16, alignItems: 'start' }}>
+      <section ref={tiersRef} id="tiers" style={{ maxWidth: 1160, margin: '0 auto', padding: '0 24px 80px' }}>
+        <div className="tier-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 14 }}>
           {/* FREE */}
           <div style={card()}>
             <TierName>Free</TierName>
@@ -444,14 +511,14 @@ function PricingPage() {
             <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>forever</div>
             <TierSeats>1 seat · no credit card required</TierSeats>
             <p style={desc()}>
-              For individuals exploring Zephyr. One cloud integration, all bundlers, and tag-based environments — free
-              forever.
+              For individuals exploring Zephyr. Full BYOC, all bundlers, and tag-based environments — free forever.
             </p>
             <Cta href="https://app.zephyr-cloud.io/" v="secondary">
               Get started free
             </Cta>
             <ul style={featList()}>
               {[
+                'BYOC — bring your own cloud',
                 '1 cloud integration',
                 'All 15 bundler plugins',
                 'Basic version history',
@@ -495,17 +562,17 @@ function PricingPage() {
             </div>
             <TierName purple>Pro</TierName>
             <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
-            <div style={amt()}>{isAnnual ? fmt(Math.round(INTRO_RATE * ANNUAL_DISC)) : fmt(INTRO_RATE)}</div>
+            <div style={amt()}>{isAnnual ? fmt(Math.round(PRO_INTRO * ANNUAL_DISC)) : fmt(PRO_INTRO)}</div>
             <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>
               per seat / month ·{' '}
-              <a href="#pro-calc" style={{ color: C.purpleLight, textDecoration: 'none', fontWeight: 600 }}>
+              <a href="#calc" style={{ color: C.purpleLight, textDecoration: 'none', fontWeight: 600 }}>
                 use the calculator ↓
               </a>
             </div>
             <TierSeats>2 – 75 seats · costs decrease as your team scales</TierSeats>
             <p style={desc()}>
-              The full platform. BYOC, MF-native features, per-team permissions, and audit logs — everything a scaling
-              engineering team needs.
+              The full deployment platform. MF-native features, BYOC, per-team permissions, and audit logs — everything
+              a shipping team needs.
             </p>
             <Cta href="https://app.zephyr-cloud.io/" v="primary">
               Start free 30-day trial
@@ -516,18 +583,16 @@ function PricingPage() {
                 color: C.grayDark,
                 textAlign: 'center',
                 marginTop: -16,
-                marginBottom: 12,
+                marginBottom: 16,
                 lineHeight: 1.5,
               }}
             >
-              No credit card required · full Pro access · keep your data after trial
+              No credit card required · full Pro access
             </div>
-            <div style={{ fontSize: 12, color: C.grayDark, marginBottom: 16 }}>Up and running in under 15 minutes.</div>
             <ul style={featList()}>
               <Fi c="green">
-                <strong style={{ color: C.white }}>BYOC</strong> — any cloud
+                <strong style={{ color: C.white }}>BYOC</strong> — all cloud integrations
               </Fi>
-              <Fi c="green">All cloud integrations</Fi>
               <Fi c="green">Instant rollbacks</Fi>
               <Fi c="green">Full version history</Fi>
               <Divider />
@@ -548,9 +613,85 @@ function PricingPage() {
               </Fi>
               <Divider />
               <Fi c="green">Per-team deploy permissions</Fi>
-              <Fi c="amber">30-day audit logs</Fi>
-              <Fi c="amber">Application activity log</Fi>
+              <Fi c="green">30-day audit logs</Fi>
               <Fi c="green">Up to 75 collaborators</Fi>
+            </ul>
+          </div>
+
+          {/* BUSINESS */}
+          <div
+            style={{
+              ...card(),
+              background: 'linear-gradient(160deg,#2A1F08 0%,#0F0F1A 60%)',
+              border: `1px solid ${C.amber}`,
+              boxShadow: '0 0 48px rgba(232,168,48,0.1)',
+            }}
+          >
+            <div
+              style={{
+                position: 'absolute',
+                top: -12,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                background: C.amber,
+                color: '#0A0A0F',
+                fontSize: 10,
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.8px',
+                padding: '4px 14px',
+                borderRadius: 10,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              For Growing Teams
+            </div>
+            <TierName amber>Business</TierName>
+            <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
+            <div style={amt()}>{isAnnual ? fmt(Math.round(BIZ_INTRO * ANNUAL_DISC)) : fmt(BIZ_INTRO)}</div>
+            <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>
+              per seat / month ·{' '}
+              <a
+                href="#calc"
+                onClick={() => setCalcTab('biz')}
+                style={{ color: C.amber, textDecoration: 'none', fontWeight: 600 }}
+              >
+                use the calculator ↓
+              </a>
+            </div>
+            <TierSeats>2 – 200 seats · SSO, SLAs, and governance included</TierSeats>
+            <p style={desc()}>
+              For teams that need SSO, approval workflows, and SLA guarantees. The governance layer between Pro and
+              Enterprise — without the Enterprise price tag.
+            </p>
+            <Cta href="https://app.zephyr-cloud.io/" v="amber">
+              Start free 30-day trial
+            </Cta>
+            <div
+              style={{
+                fontSize: 11,
+                color: C.grayDark,
+                textAlign: 'center',
+                marginTop: -16,
+                marginBottom: 16,
+                lineHeight: 1.5,
+              }}
+            >
+              No credit card required · full Business access
+            </div>
+            <ul style={featList()}>
+              <Fi c="amber">
+                <strong style={{ color: C.white }}>Everything in Pro</strong>
+              </Fi>
+              <Divider />
+              <Fi c="amber">SSO / SAML</Fi>
+              <Fi c="amber">Advanced roles &amp; permissions</Fi>
+              <Fi c="amber">Deployment approval workflows</Fi>
+              <Fi c="amber">Webhook integrations</Fi>
+              <Fi c="amber">90-day audit logs</Fi>
+              <Fi c="amber">99.9% uptime SLA</Fi>
+              <Fi c="amber">Priority support</Fi>
+              <Fi c="amber">Up to 200 collaborators</Fi>
             </ul>
           </div>
 
@@ -559,30 +700,31 @@ function PricingPage() {
             <TierName>Enterprise</TierName>
             <div style={amt()}>Custom</div>
             <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>&nbsp;</div>
-            <TierSeats>76+ seats · no RFP required · quote same day</TierSeats>
+            <TierSeats>200+ seats · no RFP required · quote same day</TierSeats>
             <p style={desc()}>
-              For large orgs and regulated sectors. SSO, extended audit retention, DPA, dedicated support, and custom
-              SLAs. Pay by invoice. POC / pilot available.
+              For large orgs and regulated sectors. SOC 2, DPA, dedicated CSM, and custom SLAs. Pay by invoice. POC /
+              pilot available.
             </p>
             <Cta href="mailto:inbound@zephyr-cloud.io?subject=Enterprise" v="secondary">
               Talk to sales
             </Cta>
             <ul style={featList()}>
               <Fi c="green">
-                <strong style={{ color: C.white }}>Everything in Pro</strong>
+                <strong style={{ color: C.white }}>Everything in Business</strong>
               </Fi>
               <Divider />
               {[
-                'SSO / SAML',
-                '60–90 day audit logs',
-                '99.9% uptime SLA',
+                'SOC 2 Type II compliance',
                 'Data Processing Agreement',
-                'SOC 2 compliant',
-                'Dedicated support',
+                'Dedicated CSM',
+                'Custom SLA (99.99%)',
+                'Negotiated contracts',
+                'Invoice / PO billing',
+                'White-glove onboarding',
                 'Custom bandwidth / storage',
-                'Custom SLAs',
+                'Unlimited collaborators',
               ].map((f) => (
-                <Fi key={f} c="amber">
+                <Fi key={f} c="green">
                   {f}
                 </Fi>
               ))}
@@ -592,7 +734,7 @@ function PricingPage() {
       </section>
 
       {/* ── ROI BANNER ── */}
-      <div style={{ maxWidth: 960, margin: '-56px auto 72px', padding: '0 24px', textAlign: 'center' }}>
+      <div style={{ maxWidth: 1160, margin: '-56px auto 72px', padding: '0 24px', textAlign: 'center' }}>
         <div
           style={{
             background: C.black3,
@@ -611,18 +753,71 @@ function PricingPage() {
         </div>
       </div>
 
-      {/* ── PRO CALCULATOR ── */}
-      <div id="pro-calc" style={{ maxWidth: 960, margin: '0 auto 72px', padding: '0 24px' }}>
+      {/* ── CALCULATOR ── */}
+      <div id="calc" style={{ maxWidth: 960, margin: '0 auto 72px', padding: '0 24px' }}>
+        {/* Tab switcher */}
         <div
           style={{
-            background: 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)',
-            border: `1px solid ${C.purple}`,
-            borderRadius: 14,
-            padding: '40px 48px',
+            display: 'flex',
+            borderRadius: '14px 14px 0 0',
+            overflow: 'hidden',
+            border: `1px solid ${calcTab === 'pro' ? C.purple : C.amber}`,
+            borderBottom: 'none',
           }}
         >
-          {/* Header */}
+          {(
+            [
+              {
+                id: 'pro',
+                label: 'Pro Calculator',
+                color: C.purple,
+                activeBg: 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)',
+              },
+              {
+                id: 'biz',
+                label: 'Business Calculator',
+                color: C.amber,
+                activeBg: 'linear-gradient(160deg,#2A1F08 0%,#0F0F1A 60%)',
+              },
+            ] as const
+          ).map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setCalcTab(tab.id)}
+              style={{
+                flex: 1,
+                padding: '12px 20px',
+                background: calcTab === tab.id ? tab.activeBg : C.black3,
+                border: 'none',
+                color: calcTab === tab.id ? tab.color : C.grayDark,
+                fontSize: 13,
+                fontWeight: 700,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                transition: 'all 0.2s',
+                letterSpacing: '0.3px',
+              }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Calc body */}
+        <div
+          style={{
+            background:
+              calcTab === 'pro'
+                ? 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)'
+                : 'linear-gradient(160deg,#2A1F08 0%,#0F0F1A 60%)',
+            border: `1px solid ${calcTab === 'pro' ? C.purple : C.amber}`,
+            borderRadius: '0 0 14px 14px',
+            padding: '40px 48px',
+            transition: 'background 0.3s, border-color 0.3s',
+          }}
+        >
           <div
+            className="calc-header"
             style={{
               display: 'flex',
               justifyContent: 'space-between',
@@ -634,7 +829,7 @@ function PricingPage() {
           >
             <div>
               <h3 style={{ fontSize: 18, fontWeight: 900, letterSpacing: '-0.4px', color: C.white, marginBottom: 6 }}>
-                Pro — see your exact price
+                {calcTab === 'pro' ? 'Pro' : 'Business'} — see your exact price
               </h3>
               <p style={{ fontSize: 13, color: C.gray, maxWidth: 400, lineHeight: 1.6 }}>
                 The more seats you add, the less you pay per seat. Click a tier or drag the slider.
@@ -647,19 +842,19 @@ function PricingPage() {
                   fontWeight: 700,
                   textTransform: 'uppercase',
                   letterSpacing: '0.8px',
-                  color: C.purpleLight,
+                  color: calcTab === 'pro' ? C.purpleLight : C.amber,
                   marginBottom: 4,
                 }}
               >
                 {isAnnual ? 'Effective per month (annual)' : 'Total per month'}
               </div>
               <div style={{ fontSize: 42, fontWeight: 900, letterSpacing: '-1.5px', color: C.white, lineHeight: 1 }}>
-                {fmt(moTotal)}
+                {fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}
               </div>
               <div style={{ fontSize: 12, color: C.gray, marginTop: 4 }}>
                 {isAnnual
-                  ? `Billed as ${fmt(yrTotal)}/yr · you save ${fmt(yrSave)}`
-                  : `${fmt(yrTotal)}/yr with annual billing — save ${fmt(yrSave)}`}
+                  ? `Billed as ${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr · you save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`
+                  : `${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr with annual — save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`}
               </div>
             </div>
           </div>
@@ -669,16 +864,18 @@ function PricingPage() {
             <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
               <span style={{ fontSize: 12, color: C.grayDark, fontWeight: 500 }}>Seats</span>
               <strong style={{ fontSize: 14, color: C.white, fontWeight: 800 }}>
-                {seats} seat{seats !== 1 ? 's' : ''}
+                {calcTab === 'pro' ? proSeats : bizSeats} seats
               </strong>
             </div>
             <input
               type="range"
               min={2}
-              max={75}
-              value={seats}
-              onChange={(e) => setSeats(parseInt(e.target.value))}
-              className="pricing-slider"
+              max={calcTab === 'pro' ? 75 : 200}
+              value={calcTab === 'pro' ? proSeats : bizSeats}
+              onChange={(e) =>
+                calcTab === 'pro' ? setProSeats(parseInt(e.target.value)) : setBizSeats(parseInt(e.target.value))
+              }
+              className={calcTab === 'pro' ? 'pricing-slider' : 'pricing-slider-biz'}
               style={{
                 width: '100%',
                 height: 5,
@@ -686,25 +883,31 @@ function PricingPage() {
                 outline: 'none',
                 WebkitAppearance: 'none',
                 cursor: 'pointer',
-                background: `linear-gradient(to right,${C.purple} 0%,${C.purple} ${sliderPct}%,${C.borderLight} ${sliderPct}%,${C.borderLight} 100%)`,
+                background: `linear-gradient(to right,${calcTab === 'pro' ? C.purple : C.amber} 0%,${calcTab === 'pro' ? C.purple : C.amber} ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,${C.borderLight} ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,${C.borderLight} 100%)`,
               }}
             />
           </div>
 
           {/* Band cards */}
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, marginBottom: 24 }}>
-            {PRO_BANDS.map((band, i) => {
+          <div
+            className="band-grid"
+            style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, marginBottom: 24 }}
+          >
+            {(calcTab === 'pro' ? PRO_BANDS : BIZ_BANDS).map((band, i) => {
+              const acColor = calcTab === 'pro' ? C.purple : C.amber;
+              const introRate = calcTab === 'pro' ? PRO_INTRO : BIZ_INTRO;
               const dr = isAnnual ? Math.round(band.rate * ANNUAL_DISC) : band.rate;
-              const saving = Math.round((1 - band.rate / INTRO_RATE) * 100);
-              const active = bandIdx === i;
+              const saving = Math.round((1 - band.rate / introRate) * 100);
+              const active = calcTab === 'pro' ? proBandIdx === i : bizBandIdx === i;
+              const rgbActive = calcTab === 'pro' ? '139,92,246' : '232,168,48';
               return (
                 <div
                   key={i}
-                  onClick={() => setSeats(band.midpoint)}
+                  onClick={() => (calcTab === 'pro' ? setProSeats(band.midpoint) : setBizSeats(band.midpoint))}
                   style={{
-                    background: active ? 'rgba(139,92,246,0.15)' : 'rgba(255,255,255,0.04)',
-                    border: `1px solid ${active ? C.purple : 'rgba(255,255,255,0.06)'}`,
-                    boxShadow: active ? '0 0 16px rgba(139,92,246,0.1)' : 'none',
+                    background: active ? `rgba(${rgbActive},0.15)` : 'rgba(255,255,255,0.04)',
+                    border: `1px solid ${active ? acColor : 'rgba(255,255,255,0.06)'}`,
+                    boxShadow: active ? `0 0 16px rgba(${rgbActive},0.1)` : 'none',
                     borderRadius: 8,
                     padding: '14px 12px',
                     textAlign: 'center',
@@ -718,7 +921,7 @@ function PricingPage() {
                       fontWeight: 700,
                       textTransform: 'uppercase',
                       letterSpacing: '0.5px',
-                      color: active ? C.purpleLight : C.grayDark,
+                      color: active ? acColor : C.grayDark,
                       marginBottom: 6,
                     }}
                   >
@@ -745,7 +948,7 @@ function PricingPage() {
             })}
           </div>
 
-          {/* Meta */}
+          {/* Meta row */}
           <div
             style={{
               display: 'flex',
@@ -760,15 +963,15 @@ function PricingPage() {
             <div style={{ fontSize: 12, color: C.gray }}>
               Per seat:{' '}
               <strong style={{ color: C.white }}>
-                {fmt(effRate)}
-                {isAnnual ? ` (was ${fmt(rate)})` : ''}
+                {fmt(calcTab === 'pro' ? proEffRate : bizEffRate)}
+                {isAnnual ? ` (was ${fmt(calcTab === 'pro' ? proRate : bizRate)})` : ''}
               </strong>
             </div>
             <div style={{ fontSize: 12, color: C.gray }}>
-              Monthly: <strong style={{ color: C.white }}>{fmt(moTotal)}</strong>
+              Monthly: <strong style={{ color: C.white }}>{fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}</strong>
             </div>
             <div style={{ fontSize: 12, color: C.gray }}>
-              Annual: <strong style={{ color: C.white }}>{fmt(yrTotal)}</strong>
+              Annual: <strong style={{ color: C.white }}>{fmt(calcTab === 'pro' ? proYearly : bizYearly)}</strong>
               <span
                 style={{
                   display: 'inline-block',
@@ -781,18 +984,41 @@ function PricingPage() {
                   marginLeft: 6,
                 }}
               >
-                Save {fmt(yrSave)}
+                Save {fmt(calcTab === 'pro' ? proSave : bizSave)}
               </span>
             </div>
             <div style={{ fontSize: 12, color: C.gray }}>
-              Need 76+ seats?{' '}
-              <a
-                href="mailto:inbound@zephyr-cloud.io?subject=Enterprise"
-                style={{ color: C.purpleLight, textDecoration: 'none', fontWeight: 700 }}
-              >
-                Talk to sales
-              </a>{' '}
-              — volume rates, quoted same day.
+              {calcTab === 'pro' ? (
+                <>
+                  Need governance or SSO?{' '}
+                  <button
+                    onClick={() => setCalcTab('biz')}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: C.purpleLight,
+                      fontWeight: 700,
+                      cursor: 'pointer',
+                      fontSize: 12,
+                      fontFamily: 'inherit',
+                      padding: 0,
+                    }}
+                  >
+                    See Business pricing ↑
+                  </button>
+                </>
+              ) : (
+                <>
+                  Need 200+ seats?{' '}
+                  <a
+                    href="mailto:inbound@zephyr-cloud.io?subject=Enterprise"
+                    style={{ color: C.amber, textDecoration: 'none', fontWeight: 700 }}
+                  >
+                    Talk to sales
+                  </a>{' '}
+                  — quoted same day.
+                </>
+              )}
             </div>
           </div>
         </div>
@@ -812,7 +1038,7 @@ function PricingPage() {
         }}
       >
         {[
-          { n: '6', s: ',213', l: 'Monthly active users' },
+          { n: '< 15', s: ' min', l: 'Avg. time to first deploy' },
           { n: '15', s: '+', l: 'Bundler integrations' },
           { n: '6', s: '+', l: 'Cloud integrations' },
           { n: '15', s: '+', l: 'Countries' },
@@ -888,6 +1114,7 @@ function PricingPage() {
           </div>
         </div>
         <div
+          className="stats-grid"
           style={{
             background: C.black2,
             border: `1px solid ${C.border}`,
@@ -941,146 +1168,174 @@ function PricingPage() {
       </section>
 
       {/* ── FEATURE TABLE ── */}
-      <section style={{ maxWidth: 960, margin: '0 auto 80px', padding: '0 24px' }}>
+      <section style={{ maxWidth: 1160, margin: '0 auto 80px', padding: '0 24px' }}>
         <div style={{ textAlign: 'center', marginBottom: 36 }}>
           <h2 style={{ fontSize: 28, fontWeight: 900, letterSpacing: '-0.6px', marginBottom: 8 }}>
             Everything in the platform
           </h2>
           <p style={{ fontSize: 14, color: C.gray }}>Every feature, every tier.</p>
         </div>
-        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
-          <thead>
-            <tr>
-              {[
-                ['Feature', 'left', C.grayDark, '40%'],
-                ['Free', 'center', C.grayDark],
-                ['Pro', 'center', C.purpleLight],
-                ['Enterprise', 'center', C.grayDark],
-              ].map(([label, align, color, w]) => (
-                <th
-                  key={label as string}
-                  style={{
-                    padding: '10px 16px',
-                    fontSize: 10,
-                    fontWeight: 700,
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.8px',
-                    color: color as string,
-                    textAlign: align as 'left' | 'center',
-                    borderBottom: `1px solid ${C.border}`,
-                    width: w as string | undefined,
-                  }}
-                >
-                  {label}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {(
-              [
-                { g: 'Deployment' },
-                { f: 'Cloud integrations', fr: '1', pr: 'All', en: 'All' },
-                { f: 'Bundler plugins (15)', fr: '✓', pr: '✓', en: '✓' },
-                { f: 'BYOC', fr: '—', pr: '✓', en: '✓' },
-                { f: 'Instant rollbacks', fr: '—', pr: '✓', en: '✓' },
-                { f: 'Tag / branch env', fr: '✓', pr: '✓', en: '✓' },
-                { f: 'Version history', fr: 'Limited', pr: '✓', en: 'Custom' },
-                { g: 'Module Federation Native', mfg: true },
-                { f: 'Environment Overrides', fr: '—', pr: '✓', en: '✓', mf: true },
-                { f: 'Env Variables (no redeploy)', fr: '—', pr: '✓', en: '✓' },
-                { f: 'Zephyr DevTools', fr: '—', pr: '✓', en: '✓', mf: true },
-                { f: 'UML architecture map', fr: '—', pr: '✓', en: '✓', mf: true },
-                { f: 'zephyr.dependencies', fr: '—', pr: '✓', en: '✓', mf: true },
-                { g: 'Teams & Access' },
-                { f: 'Collaborators', fr: '—', pr: 'Up to 75', en: 'Unlimited' },
-                { f: 'Per-team permissions', fr: '—', pr: '✓', en: '✓' },
-                { f: 'SSO / SAML', fr: '—', pr: '—', en: '✓' },
-                { g: 'Security & Compliance' },
-                { f: 'Activity log', fr: '—', pr: '✓', en: '✓' },
-                { f: 'Audit log retention', fr: '—', pr: '30 days', en: '60–90 days' },
-                { f: 'SOC 2 compliance', fr: '—', pr: '—', en: '✓' },
-                { f: 'DPA', fr: '—', pr: '—', en: '✓' },
-                { f: 'Uptime SLA', fr: '—', pr: '—', en: '99.9%' },
-              ] as Array<{ g?: string; mfg?: boolean; f?: string; fr?: string; pr?: string; en?: string; mf?: boolean }>
-            ).map((row, i) => {
-              if (row.g)
-                return (
-                  <tr key={i}>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, minWidth: 680 }}>
+            <thead>
+              <tr>
+                {(
+                  [
+                    ['Feature', 'left', C.grayDark, '28%'],
+                    ['Free', 'center', C.grayDark, undefined],
+                    ['Pro', 'center', C.purpleLight, undefined],
+                    ['Business', 'center', C.amber, undefined],
+                    ['Enterprise', 'center', C.grayDark, undefined],
+                  ] as [string, string, string, string | undefined][]
+                ).map(([label, align, color, w]) => (
+                  <th
+                    key={label}
+                    style={{
+                      padding: '10px 16px',
+                      fontSize: 10,
+                      fontWeight: 700,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.8px',
+                      color,
+                      textAlign: align as 'left' | 'center',
+                      borderBottom: `1px solid ${C.border}`,
+                      width: w,
+                    }}
+                  >
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {(
+                [
+                  { g: 'Deployment' },
+                  { f: 'Cloud integrations', fr: '1', pr: 'All', bz: 'All', en: 'All' },
+                  { f: 'Bundler plugins (15)', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'BYOC', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Instant rollbacks', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Tag / branch env', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Version history', fr: 'Limited', pr: '✓', bz: '✓', en: 'Custom' },
+                  { g: 'Module Federation Native', mfg: true },
+                  { f: 'Environment Overrides', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'Env Variables (no redeploy)', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Zephyr DevTools', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'UML architecture map', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'zephyr.dependencies', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { g: 'Teams & Access' },
+                  { f: 'Collaborators', fr: '—', pr: 'Up to 75', bz: 'Up to 200', en: 'Unlimited' },
+                  { f: 'Per-team permissions', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Advanced roles', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { f: 'SSO / SAML', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { f: 'Approval workflows', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { f: 'Webhook integrations', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { g: 'Security & Compliance' },
+                  { f: 'Activity log', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Audit log retention', fr: '—', pr: '30 days', bz: '90 days', en: 'Custom' },
+                  { f: 'Uptime SLA', fr: '—', pr: '—', bz: '99.9%', en: '99.99%' },
+                  { f: 'SOC 2 compliance', fr: '—', pr: '—', bz: '—', en: '✓' },
+                  { f: 'DPA', fr: '—', pr: '—', bz: '—', en: '✓' },
+                  { g: 'Support' },
+                  { f: 'Community support', fr: '✓', pr: '—', bz: '—', en: '—' },
+                  { f: 'Email support', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Priority support', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { f: 'Dedicated CSM', fr: '—', pr: '—', bz: '—', en: '✓' },
+                ] as Array<{
+                  g?: string;
+                  mfg?: boolean;
+                  f?: string;
+                  fr?: string;
+                  pr?: string;
+                  bz?: string;
+                  en?: string;
+                  mf?: boolean;
+                }>
+              ).map((row, i) => {
+                if (row.g)
+                  return (
+                    <tr key={i}>
+                      <td
+                        colSpan={5}
+                        style={{
+                          background: C.black3,
+                          color: C.grayDark,
+                          fontSize: 10,
+                          fontWeight: 700,
+                          textTransform: 'uppercase',
+                          letterSpacing: '1px',
+                          padding: '8px 16px',
+                          borderTop: `1px solid ${C.border}`,
+                        }}
+                      >
+                        {row.g}
+                        {row.mfg && (
+                          <span style={{ marginLeft: 6 }}>
+                            <MfTag />
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                const cell = (val = '', hl?: 'pro' | 'biz') => {
+                  const color =
+                    val === '✓'
+                      ? C.green
+                      : val === '—'
+                        ? C.borderLight
+                        : val === 'Limited'
+                          ? C.grayDark
+                          : val === 'Custom' || val === 'Unlimited'
+                            ? C.purpleLight
+                            : C.gray;
+                  return (
                     <td
-                      colSpan={4}
                       style={{
-                        background: C.black3,
-                        color: C.grayDark,
-                        fontSize: 10,
-                        fontWeight: 700,
-                        textTransform: 'uppercase',
-                        letterSpacing: '1px',
-                        padding: '8px 16px',
-                        borderTop: `1px solid ${C.border}`,
+                        padding: '11px 16px',
+                        borderBottom: `1px solid ${C.border}`,
+                        textAlign: 'center',
+                        color,
+                        background:
+                          hl === 'pro'
+                            ? 'rgba(139,92,246,0.04)'
+                            : hl === 'biz'
+                              ? 'rgba(232,168,48,0.04)'
+                              : 'transparent',
+                        fontSize: val === '✓' || val === '—' ? 14 : 11,
+                        fontWeight: val === 'Limited' || val === 'Custom' ? 700 : 400,
                       }}
                     >
-                      {row.g}
-                      {row.mfg && (
+                      {val}
+                    </td>
+                  );
+                };
+                return (
+                  <tr key={i} className={cn(path === 'nonmf' && row.mf && 'opacity-40')}>
+                    <td
+                      style={{
+                        padding: '11px 16px',
+                        borderBottom: `1px solid ${C.border}`,
+                        color: C.white,
+                        fontWeight: 500,
+                      }}
+                    >
+                      {row.f}
+                      {row.mf && (
                         <span style={{ marginLeft: 6 }}>
                           <MfTag />
                         </span>
                       )}
                     </td>
+                    {cell(row.fr)}
+                    {cell(row.pr, 'pro')}
+                    {cell(row.bz, 'biz')}
+                    {cell(row.en)}
                   </tr>
                 );
-              const cell = (val = '', isP = false) => {
-                const color =
-                  val === '✓'
-                    ? C.green
-                    : val === '—'
-                      ? C.borderLight
-                      : val === 'Limited'
-                        ? C.grayDark
-                        : val === 'Custom' || val === 'Unlimited'
-                          ? C.purpleLight
-                          : C.gray;
-                return (
-                  <td
-                    style={{
-                      padding: '11px 16px',
-                      borderBottom: `1px solid ${C.border}`,
-                      textAlign: 'center',
-                      color,
-                      background: isP ? 'rgba(139,92,246,0.04)' : 'transparent',
-                      fontSize: val === '✓' || val === '—' ? 14 : 11,
-                      fontWeight: val === 'Limited' || val === 'Custom' ? 700 : 400,
-                    }}
-                  >
-                    {val}
-                  </td>
-                );
-              };
-              return (
-                <tr key={i} className={cn(path === 'nonmf' && row.mf && 'opacity-40')}>
-                  <td
-                    style={{
-                      padding: '11px 16px',
-                      borderBottom: `1px solid ${C.border}`,
-                      color: C.white,
-                      fontWeight: 500,
-                    }}
-                  >
-                    {row.f}
-                    {row.mf && (
-                      <span style={{ marginLeft: 6 }}>
-                        <MfTag />
-                      </span>
-                    )}
-                  </td>
-                  {cell(row.fr)}
-                  {cell(row.pr, true)}
-                  {cell(row.en)}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+              })}
+            </tbody>
+          </table>
+        </div>
       </section>
 
       {/* ── FAQ ── */}
@@ -1198,16 +1453,30 @@ function PricingPage() {
         </div>
       </section>
 
-      {/* Slider thumb styles */}
+      {/* Slider + responsive styles */}
       <style>{`
         .pricing-slider::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:${C.purple}; cursor:pointer; box-shadow:0 0 0 4px rgba(139,92,246,0.2); border:2px solid ${C.white}; }
         .pricing-slider::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:${C.purple}; cursor:pointer; border:2px solid ${C.white}; }
+        .pricing-slider-biz::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:${C.amber}; cursor:pointer; box-shadow:0 0 0 4px rgba(232,168,48,0.2); border:2px solid ${C.white}; }
+        .pricing-slider-biz::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:${C.amber}; cursor:pointer; border:2px solid ${C.white}; }
+        @media (max-width: 960px) {
+          .tier-grid { grid-template-columns: repeat(2,1fr) !important; }
+        }
+        @media (max-width: 600px) {
+          .tier-grid { grid-template-columns: 1fr !important; }
+          .band-grid { grid-template-columns: repeat(2,1fr) !important; }
+          .value-grid { grid-template-columns: 1fr !important; }
+          .calc-header { flex-direction: column !important; }
+          .stats-grid { grid-template-columns: 1fr !important; }
+          .stats-grid > div:first-child { padding-right: 0 !important; border-right: none !important; padding-bottom: 24px; border-bottom: 1px solid ${C.border}; }
+          .stats-grid > div:last-child { padding-left: 0 !important; padding-top: 24px; }
+        }
       `}</style>
     </div>
   );
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ── Helpers ────────────────────────────────────────────────────────────────────
 const card = () => ({
   background: C.black2,
   border: `1px solid ${C.border}`,
@@ -1222,9 +1491,11 @@ const featList = () => ({
   display: 'flex' as const,
   flexDirection: 'column' as const,
   gap: 10,
+  margin: 0,
+  padding: 0,
 });
 
-function TierName({ children, purple }: { children: React.ReactNode; purple?: boolean }) {
+function TierName({ children, purple, amber }: { children: ReactNode; purple?: boolean; amber?: boolean }) {
   return (
     <div
       style={{
@@ -1232,7 +1503,7 @@ function TierName({ children, purple }: { children: React.ReactNode; purple?: bo
         fontWeight: 700,
         textTransform: 'uppercase',
         letterSpacing: '1px',
-        color: purple ? C.purpleLight : C.grayDark,
+        color: purple ? C.purpleLight : amber ? C.amber : C.grayDark,
         marginBottom: 14,
       }}
     >
@@ -1240,7 +1511,7 @@ function TierName({ children, purple }: { children: React.ReactNode; purple?: bo
     </div>
   );
 }
-function TierSeats({ children }: { children: React.ReactNode }) {
+function TierSeats({ children }: { children: ReactNode }) {
   return (
     <div
       style={{
@@ -1255,11 +1526,22 @@ function TierSeats({ children }: { children: React.ReactNode }) {
     </div>
   );
 }
-function Cta({ href, children, v }: { href: string; children: React.ReactNode; v: 'primary' | 'secondary' }) {
+function Cta({
+  href,
+  children,
+  v,
+  onClick,
+}: {
+  href: string;
+  children: ReactNode;
+  v: 'primary' | 'secondary' | 'amber';
+  onClick?: () => void;
+}) {
   return (
     <a
       href={href}
       target="_blank"
+      onClick={onClick}
       style={{
         display: 'block',
         width: '100%',
@@ -1273,14 +1555,16 @@ function Cta({ href, children, v }: { href: string; children: React.ReactNode; v
         transition: 'all 0.2s',
         ...(v === 'primary'
           ? { background: C.purple, color: 'white' }
-          : { background: 'transparent', border: `1px solid ${C.borderLight}`, color: C.white }),
+          : v === 'amber'
+            ? { background: C.amber, color: '#0A0A0F' }
+            : { background: 'transparent', border: `1px solid ${C.borderLight}`, color: C.white }),
       }}
     >
       {children}
     </a>
   );
 }
-function Fi({ children, c, dim }: { children: React.ReactNode; c: 'green' | 'purple' | 'amber'; dim?: boolean }) {
+function Fi({ children, c, dim }: { children: ReactNode; c: 'green' | 'purple' | 'amber'; dim?: boolean }) {
   const ic = c === 'green' ? C.green : c === 'purple' ? C.purpleLight : C.amber;
   return (
     <li
@@ -1300,26 +1584,21 @@ function Fi({ children, c, dim }: { children: React.ReactNode; c: 'green' | 'pur
   );
 }
 function Divider() {
-  return (
-    <li>
-      <hr style={{ border: 'none', borderTop: `1px dashed ${C.border}`, margin: '6px 0' }} />
-    </li>
-  );
+  return <li style={{ listStyle: 'none', height: 1, background: C.border, margin: '4px 0' }} />;
 }
 function MfTag() {
   return (
     <span
       style={{
-        background: C.purpleDim,
-        color: C.purpleLight,
         fontSize: 9,
         fontWeight: 700,
         textTransform: 'uppercase',
         letterSpacing: '0.5px',
+        background: C.purpleDim,
+        color: C.purpleLight,
+        border: `1px solid rgba(139,92,246,0.3)`,
         padding: '1px 5px',
         borderRadius: 3,
-        marginLeft: 4,
-        verticalAlign: 'middle',
       }}
     >
       MF

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -89,7 +89,6 @@ function PricingPage() {
   const proYearly = Math.round(proSeats * proRate * 12 * ANNUAL_DISC);
   const proSave = Math.round(proSeats * proRate * 12 - proYearly);
   const proBandIdx = getProBandIdx(proSeats);
-  const proSliderPct = ((proSeats - 2) / 73) * 100;
 
   // Business calc
   const bizRate = getBizRate(bizSeats);
@@ -98,7 +97,6 @@ function PricingPage() {
   const bizYearly = Math.round(bizSeats * bizRate * 12 * ANNUAL_DISC);
   const bizSave = Math.round(bizSeats * bizRate * 12 - bizYearly);
   const bizBandIdx = getBizBandIdx(bizSeats);
-  const bizSliderPct = ((bizSeats - 2) / 198) * 100;
 
   const faqs = [
     {
@@ -838,7 +836,7 @@ function PricingPage() {
                 {calcTab === 'pro' ? 'Teams' : 'Business'} — see your exact price
               </h3>
               <p style={{ fontSize: 13, color: C.gray, maxWidth: 400, lineHeight: 1.6 }}>
-                The more seats you add, the less you pay per seat. Click a tier or drag the slider.
+                The more seats you add, the less you pay per seat. Click a tier to see your price.
               </p>
             </div>
             <div style={{ textAlign: 'right', flexShrink: 0 }}>
@@ -863,35 +861,6 @@ function PricingPage() {
                   : `${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr with annual — save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`}
               </div>
             </div>
-          </div>
-
-          {/* Slider */}
-          <div style={{ marginBottom: 28 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-              <span style={{ fontSize: 12, color: C.grayDark, fontWeight: 500 }}>Seats</span>
-              <strong style={{ fontSize: 14, color: C.white, fontWeight: 800 }}>
-                {calcTab === 'pro' ? proSeats : bizSeats} seats
-              </strong>
-            </div>
-            <input
-              type="range"
-              min={2}
-              max={calcTab === 'pro' ? 75 : 200}
-              value={calcTab === 'pro' ? proSeats : bizSeats}
-              onChange={(e) =>
-                calcTab === 'pro' ? setProSeats(parseInt(e.target.value)) : setBizSeats(parseInt(e.target.value))
-              }
-              className={calcTab === 'pro' ? 'pricing-slider' : 'pricing-slider-biz'}
-              style={{
-                width: '100%',
-                height: 5,
-                borderRadius: 3,
-                outline: 'none',
-                WebkitAppearance: 'none',
-                cursor: 'pointer',
-                background: `linear-gradient(to right,${calcTab === 'pro' ? C.purple : C.amber} 0%,${calcTab === 'pro' ? C.purple : C.amber} ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,${C.borderLight} ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,${C.borderLight} 100%)`,
-              }}
-            />
           </div>
 
           {/* Band cards */}
@@ -1459,12 +1428,8 @@ function PricingPage() {
         </div>
       </section>
 
-      {/* Slider + responsive styles */}
+      {/* Responsive styles */}
       <style>{`
-        .pricing-slider::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:${C.purple}; cursor:pointer; box-shadow:0 0 0 4px rgba(139,92,246,0.2); border:2px solid ${C.white}; }
-        .pricing-slider::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:${C.purple}; cursor:pointer; border:2px solid ${C.white}; }
-        .pricing-slider-biz::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:${C.amber}; cursor:pointer; box-shadow:0 0 0 4px rgba(232,168,48,0.2); border:2px solid ${C.white}; }
-        .pricing-slider-biz::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:${C.amber}; cursor:pointer; border:2px solid ${C.white}; }
         @media (max-width: 960px) {
           .tier-grid { grid-template-columns: repeat(2,1fr) !important; }
         }

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -997,6 +997,32 @@ function PricingPage() {
               )}
             </div>
           </div>
+
+          {/* Checkout CTA */}
+          <div style={{ marginTop: 24, display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
+            <a
+              href="https://app.zephyr-cloud.io/"
+              target="_blank"
+              rel="noopener"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 10,
+                padding: '13px 28px',
+                borderRadius: 8,
+                fontWeight: 700,
+                fontSize: 14,
+                textDecoration: 'none',
+                transition: 'all 0.2s',
+                background: calcTab === 'pro' ? C.purple : C.amber,
+                color: calcTab === 'pro' ? 'white' : '#0A0A0F',
+              }}
+            >
+              Get started — {calcTab === 'pro' ? proSeats : bizSeats} seats ·{' '}
+              {fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}/mo
+            </a>
+            <span style={{ fontSize: 12, color: C.grayDark }}>No credit card required · free 30-day trial</span>
+          </div>
         </div>
       </div>
 

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1069,11 +1069,9 @@ function PricingPage() {
                   >
                     <div
                       style={{
-                        fontSize: 11,
-                        fontWeight: 600,
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.8px',
-                        color: 'var(--muted-foreground)',
+                        fontSize: 14,
+                        fontWeight: 500,
+                        color: 'var(--foreground)',
                         marginBottom: 14,
                       }}
                     >
@@ -1093,9 +1091,7 @@ function PricingPage() {
                             padding: '16px 18px',
                           }}
                         >
-                          <div
-                            style={{ fontSize: 11, color: 'var(--muted-foreground)', marginBottom: 6, lineHeight: 1.4 }}
-                          >
+                          <div style={{ fontSize: 11, color: 'var(--foreground)', marginBottom: 6, lineHeight: 1.4 }}>
                             {label}
                           </div>
                           <div

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -89,6 +89,7 @@ function PricingPage() {
   const proYearly = Math.round(proSeats * proRate * 12 * ANNUAL_DISC);
   const proSave = Math.round(proSeats * proRate * 12 - proYearly);
   const proBandIdx = getProBandIdx(proSeats);
+  const proSliderPct = ((proSeats - 2) / 73) * 100;
 
   // Business calc
   const bizRate = getBizRate(bizSeats);
@@ -97,6 +98,7 @@ function PricingPage() {
   const bizYearly = Math.round(bizSeats * bizRate * 12 * ANNUAL_DISC);
   const bizSave = Math.round(bizSeats * bizRate * 12 - bizYearly);
   const bizBandIdx = getBizBandIdx(bizSeats);
+  const bizSliderPct = ((bizSeats - 2) / 198) * 100;
 
   const faqs = [
     {
@@ -836,7 +838,7 @@ function PricingPage() {
                 {calcTab === 'pro' ? 'Teams' : 'Business'} — see your exact price
               </h3>
               <p style={{ fontSize: 13, color: C.gray, maxWidth: 400, lineHeight: 1.6 }}>
-                The more seats you add, the less you pay per seat. Click a tier to see your price.
+                The more seats you add, the less you pay per seat. Click a tier or drag the slider.
               </p>
             </div>
             <div style={{ textAlign: 'right', flexShrink: 0 }}>
@@ -861,6 +863,35 @@ function PricingPage() {
                   : `${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr with annual — save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`}
               </div>
             </div>
+          </div>
+
+          {/* Slider */}
+          <div style={{ marginBottom: 28 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+              <span style={{ fontSize: 12, color: C.grayDark, fontWeight: 500 }}>Seats</span>
+              <strong style={{ fontSize: 14, color: C.white, fontWeight: 800 }}>
+                {calcTab === 'pro' ? proSeats : bizSeats} seats
+              </strong>
+            </div>
+            <input
+              type="range"
+              min={2}
+              max={calcTab === 'pro' ? 75 : 200}
+              value={calcTab === 'pro' ? proSeats : bizSeats}
+              onChange={(e) =>
+                calcTab === 'pro' ? setProSeats(parseInt(e.target.value)) : setBizSeats(parseInt(e.target.value))
+              }
+              className={calcTab === 'pro' ? 'pricing-slider' : 'pricing-slider-biz'}
+              style={{
+                width: '100%',
+                height: 5,
+                borderRadius: 3,
+                outline: 'none',
+                WebkitAppearance: 'none',
+                cursor: 'pointer',
+                background: `linear-gradient(to right,${calcTab === 'pro' ? C.purple : C.amber} 0%,${calcTab === 'pro' ? C.purple : C.amber} ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,${C.borderLight} ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,${C.borderLight} 100%)`,
+              }}
+            />
           </div>
 
           {/* Band cards */}
@@ -1428,8 +1459,12 @@ function PricingPage() {
         </div>
       </section>
 
-      {/* Responsive styles */}
+      {/* Slider + responsive styles */}
       <style>{`
+        .pricing-slider::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:${C.purple}; cursor:pointer; box-shadow:0 0 0 4px rgba(139,92,246,0.2); border:2px solid ${C.white}; }
+        .pricing-slider::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:${C.purple}; cursor:pointer; border:2px solid ${C.white}; }
+        .pricing-slider-biz::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:${C.amber}; cursor:pointer; box-shadow:0 0 0 4px rgba(232,168,48,0.2); border:2px solid ${C.white}; }
+        .pricing-slider-biz::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:${C.amber}; cursor:pointer; border:2px solid ${C.white}; }
         @media (max-width: 960px) {
           .tier-grid { grid-template-columns: repeat(2,1fr) !important; }
         }

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -8,24 +8,9 @@ export const Route = createFileRoute('/pricing')({
   component: PricingPage,
 });
 
-// ── Design tokens ──────────────────────────────────────────────────────────────
-const C = {
-  black: '#0A0A0F',
-  black2: '#0F0F1A',
-  black3: '#111118',
-  border: '#1E1E2E',
-  borderLight: '#2D2D3A',
-  purple: '#8B5CF6',
-  purpleLight: '#A78BFA',
-  purpleDim: '#1A0F3A',
-  white: '#F5F4F0',
-  gray: '#9CA3AF',
-  grayDark: '#6B7280',
-  green: '#10B981',
-  greenDim: '#064E3B',
-  amber: '#E8A830',
-  amberDim: '#2A1F08',
-} as const;
+// Non-MF path accent — no DS variable for green
+const GREEN = '#10B981';
+const GREEN_DIM = '#064E3B';
 
 // ── Volume bands ───────────────────────────────────────────────────────────────
 const PRO_BANDS = [
@@ -69,6 +54,9 @@ function PricingPage() {
   const [calcTab, setCalcTab] = useState<'pro' | 'biz'>('pro');
   const [openFaq, setOpenFaq] = useState<number | null>(null);
   const [mobilePlan, setMobilePlan] = useState<'fr' | 'pr' | 'bz' | 'en'>('fr');
+  const [showCalc, setShowCalc] = useState(false);
+  const [showOverages, setShowOverages] = useState(false);
+  const [animatedTotal, setAnimatedTotal] = useState(0);
   const billingRef = useRef<HTMLDivElement>(null);
   const tiersRef = useRef<HTMLElement>(null);
   const panelsRef = useRef<HTMLDivElement>(null);
@@ -102,6 +90,22 @@ function PricingPage() {
   const bizSave = Math.round(bizSeats * bizRate * 12 - bizYearly);
   const bizBandIdx = getBizBandIdx(bizSeats);
   const bizSliderPct = ((bizSeats - 2) / 198) * 100;
+
+  const calcMonthly = calcTab === 'pro' ? proMonthly : bizMonthly;
+  useEffect(() => {
+    const start = animatedTotal;
+    const end = calcMonthly;
+    const duration = 300;
+    const startTime = Date.now();
+    const animate = () => {
+      const elapsed = Date.now() - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setAnimatedTotal(Math.round(start + (end - start) * eased));
+      if (progress < 1) requestAnimationFrame(animate);
+    };
+    requestAnimationFrame(animate);
+  }, [calcMonthly]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const faqs = [
     {
@@ -149,7 +153,7 @@ function PricingPage() {
   return (
     <div style={{ background: 'var(--background)', color: 'var(--foreground)', lineHeight: 1.6 }}>
       {/* ── HERO ── */}
-      <section style={{ textAlign: 'center', padding: '64px 40px 20px', maxWidth: 760, margin: '0 auto' }}>
+      <section style={{ textAlign: 'center', padding: '64px 40px 24px', maxWidth: 760, margin: '0 auto' }}>
         <h1 className="text-5xl font-medium leading-tighter mb-4 text-white">Pricing that scales with your team</h1>
         <p className="text-xl text-muted-foreground">Start for free and scale as you grow.</p>
       </section>
@@ -176,13 +180,17 @@ function PricingPage() {
           ).map(({ id, icon, title, sub }) => {
             const active = path === id;
             const isMf = id === 'mf';
-            const activeColor = isMf ? 'var(--primary)' : C.green;
+            const activeColor = isMf ? 'var(--primary)' : GREEN;
             return (
               <button
                 key={id}
                 onClick={() => selectPath(id)}
                 style={{
-                  background: active ? (isMf ? 'rgba(139,92,246,0.12)' : 'rgba(16,185,129,0.1)') : 'var(--card)',
+                  background: active
+                    ? isMf
+                      ? 'color-mix(in oklch, var(--primary) 12%, transparent)'
+                      : `color-mix(in oklch, ${GREEN} 10%, transparent)`
+                    : 'var(--card)',
                   borderRadius: 12,
                   padding: '22px 28px',
                   cursor: 'pointer',
@@ -194,7 +202,7 @@ function PricingPage() {
                   transition: 'all 0.25s',
                   border: `2px solid ${active ? activeColor : 'var(--border)'}`,
                   boxShadow: active
-                    ? `0 0 0 1px ${activeColor}, 0 8px 32px ${isMf ? 'rgba(139,92,246,0.2)' : 'rgba(16,185,129,0.15)'}`
+                    ? `0 0 0 1px ${activeColor}, 0 8px 32px ${isMf ? 'color-mix(in oklch, var(--primary) 20%, transparent)' : `color-mix(in oklch, ${GREEN} 15%, transparent)`}`
                     : 'none',
                   transform: active ? 'translateY(-2px)' : 'none',
                   fontFamily: 'inherit',
@@ -251,7 +259,7 @@ function PricingPage() {
         {(['mf', 'nonmf'] as const).map((panelId) => {
           const isMf = panelId === 'mf';
           const visible = path === panelId;
-          const accent = isMf ? 'var(--primary-muted)' : C.green;
+          const accent = isMf ? 'var(--primary-muted)' : GREEN;
           const pains = isMf
             ? [
                 {
@@ -313,9 +321,9 @@ function PricingPage() {
                   borderRadius: 14,
                   padding: '40px 48px',
                   background: isMf
-                    ? 'linear-gradient(135deg,#1A0F3A 0%,#0F0F1A 70%)'
-                    : 'linear-gradient(135deg,#062A1F 0%,#0F0F1A 70%)',
-                  border: `1px solid ${isMf ? 'rgba(139,92,246,0.3)' : 'rgba(16,185,129,0.25)'}`,
+                    ? 'linear-gradient(135deg, color-mix(in oklch, var(--primary) 20%, var(--card)) 0%, var(--card) 70%)'
+                    : `linear-gradient(135deg, color-mix(in oklch, ${GREEN_DIM} 80%, var(--card)) 0%, var(--card) 70%)`,
+                  border: `1px solid ${isMf ? 'color-mix(in oklch, var(--primary) 30%, transparent)' : `color-mix(in oklch, ${GREEN} 25%, transparent)`}`,
                 }}
               >
                 <div style={{ marginBottom: 32 }}>
@@ -425,7 +433,7 @@ function PricingPage() {
                 fontSize: 13,
                 fontWeight: 600,
                 padding: '8px 16px',
-                borderRadius: 30,
+                borderRadius: 9999,
                 cursor: 'pointer',
                 transition: 'all 0.2s',
                 fontFamily: 'inherit',
@@ -435,27 +443,13 @@ function PricingPage() {
               }}
             >
               {mode === 'monthly' ? 'Monthly' : 'Yearly'}
-              {mode === 'annual' && (
-                <span
-                  style={{
-                    background: C.greenDim,
-                    color: C.green,
-                    fontSize: 12,
-                    fontWeight: 500,
-                    padding: '2px 8px',
-                    borderRadius: 8,
-                  }}
-                >
-                  Save 15%
-                </span>
-              )}
             </button>
           ))}
         </div>
       </div>
 
       {/* ── TIER CARDS ── */}
-      <section ref={tiersRef} id="tiers" style={{ maxWidth: 1160, margin: '0 auto', padding: '0 24px 80px' }}>
+      <section ref={tiersRef} id="tiers" style={{ maxWidth: 1280, margin: '0 auto', padding: '0 24px 80px' }}>
         <div className="tier-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 14 }}>
           {/* FREE */}
           <div style={card()}>
@@ -491,7 +485,7 @@ function PricingPage() {
                   >
                     0
                   </span>
-                  <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 6, fontWeight: 400 }}>
+                  <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 4, fontWeight: 400 }}>
                     /seat/mo.
                   </span>
                 </div>
@@ -523,7 +517,8 @@ function PricingPage() {
           <div
             style={{
               ...card(),
-              background: 'linear-gradient(193.6deg, var(--card) 0%, rgba(124,58,237,0.35) 100%)',
+              background:
+                'linear-gradient(193.6deg, var(--card) 0%, color-mix(in oklch, var(--primary) 28%, transparent) 100%)',
               border: '2px solid var(--primary)',
             }}
           >
@@ -540,8 +535,8 @@ function PricingPage() {
                     color: 'var(--primary-foreground)',
                     fontSize: 11,
                     fontWeight: 600,
-                    padding: '3px 10px',
-                    borderRadius: 6,
+                    padding: '4px 8px',
+                    borderRadius: 8,
                   }}
                 >
                   Popular
@@ -573,7 +568,7 @@ function PricingPage() {
                   >
                     {isAnnual ? Math.round(PRO_INTRO * ANNUAL_DISC) : PRO_INTRO}
                   </span>
-                  <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 6, fontWeight: 400 }}>
+                  <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 4, fontWeight: 400 }}>
                     /seat/mo.
                   </span>
                 </div>
@@ -586,24 +581,24 @@ function PricingPage() {
             <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
               <ul style={featList()}>
                 <Fi c="green">
-                  <strong style={{ color: 'var(--foreground)' }}>BYOC</strong> — all cloud integrations
+                  <span style={{ color: 'var(--foreground)' }}>BYOC</span> — all cloud integrations
                 </Fi>
                 <Fi c="green">Instant rollbacks</Fi>
                 <Fi c="green">Full version history</Fi>
                 <Fi c="purple" dim={path === 'nonmf'} mf>
-                  <strong style={{ color: 'var(--foreground)' }}>Environment Overrides</strong>
+                  <span style={{ color: 'var(--foreground)' }}>Environment Overrides</span>
                 </Fi>
                 <Fi c="purple">
-                  <strong style={{ color: 'var(--foreground)' }}>Env Variables</strong> — no redeploy
+                  <span style={{ color: 'var(--foreground)' }}>Env Variables</span> — no redeploy
                 </Fi>
                 <Fi c="purple" dim={path === 'nonmf'} mf>
-                  <strong style={{ color: 'var(--foreground)' }}>Zephyr DevTools</strong>
+                  <span style={{ color: 'var(--foreground)' }}>Zephyr DevTools</span>
                 </Fi>
                 <Fi c="purple" dim={path === 'nonmf'} mf>
-                  <strong style={{ color: 'var(--foreground)' }}>UML architecture map</strong>
+                  <span style={{ color: 'var(--foreground)' }}>UML architecture map</span>
                 </Fi>
                 <Fi c="purple" dim={path === 'nonmf'} mf>
-                  <strong style={{ color: 'var(--foreground)' }}>zephyr.dependencies</strong>
+                  <span style={{ color: 'var(--foreground)' }}>zephyr.dependencies</span>
                 </Fi>
                 <Fi c="green">Per-team deploy permissions</Fi>
                 <Fi c="green">30-day audit logs</Fi>
@@ -650,7 +645,7 @@ function PricingPage() {
                   >
                     {isAnnual ? Math.round(BIZ_INTRO * ANNUAL_DISC) : BIZ_INTRO}
                   </span>
-                  <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 6, fontWeight: 400 }}>
+                  <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 4, fontWeight: 400 }}>
                     /seat/mo.
                   </span>
                 </div>
@@ -698,19 +693,17 @@ function PricingPage() {
                 >
                   starting at
                 </div>
-                <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
+                <div style={{ display: 'flex', alignItems: 'center', minHeight: 36 }}>
                   <span
                     style={{
-                      fontSize: 36,
+                      fontSize: 20,
                       fontWeight: 600,
                       color: 'var(--foreground)',
-                      letterSpacing: '-1px',
                       lineHeight: 1,
                     }}
                   >
-                    Custom
+                    Custom pricing
                   </span>
-                  <span style={{ fontSize: 14, color: 'transparent', marginLeft: 6, fontWeight: 400 }}>/seat/mo.</span>
                 </div>
               </div>
               <Cta href="mailto:inbound@zephyr-cloud.io?subject=Enterprise" v="secondary">
@@ -745,377 +738,310 @@ function PricingPage() {
       </section>
 
       {/* ── CALCULATOR ── */}
-      <div id="calc" style={{ maxWidth: 960, margin: '0 auto 72px', padding: '0 24px' }}>
-        {/* Single outer border wraps tabs + body — no double borders */}
-        <div
-          style={{
-            border: `1px solid ${calcTab === 'pro' ? 'var(--primary)' : 'rgba(255,255,255,0.18)'}`,
-            borderRadius: 14,
-            overflow: 'hidden',
-            transition: 'border-color 0.3s',
-          }}
-        >
-          {/* Tab switcher */}
-          <div
+      <div id="calc" style={{ maxWidth: 640, margin: '0 auto 72px', padding: '0 24px' }}>
+        <div style={{ textAlign: 'center', marginBottom: 24 }}>
+          <p style={{ fontSize: 14, color: 'var(--muted-foreground)', marginBottom: 16 }}>
+            Seats-based pricing — see your exact monthly total.
+          </p>
+          <button
+            onClick={() => setShowCalc((v) => !v)}
             style={{
-              display: 'flex',
-              borderBottom: `1px solid ${calcTab === 'pro' ? 'var(--primary)' : 'rgba(255,255,255,0.18)'}`,
-              transition: 'border-color 0.3s',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '8px 16px',
+              borderRadius: 8,
+              background: 'var(--secondary)',
+              color: 'var(--secondary-foreground)',
+              border: 'none',
+              fontSize: 14,
+              fontWeight: 500,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              transition: 'opacity 0.2s',
             }}
           >
-            {(
-              [
-                {
-                  id: 'pro',
-                  label: 'Teams Calculator',
-                  color: 'var(--foreground)' as string,
-                  activeBg: 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)',
-                },
-                {
-                  id: 'biz',
-                  label: 'Business Calculator',
-                  color: 'var(--foreground)' as string,
-                  activeBg: 'var(--card)',
-                },
-              ] as const
-            ).map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => setCalcTab(tab.id)}
-                style={{
-                  flex: 1,
-                  padding: '8px 16px',
-                  background: calcTab === tab.id ? tab.activeBg : 'var(--card)',
-                  border: 'none',
-                  color: calcTab === tab.id ? tab.color : 'var(--muted-foreground)',
-                  fontSize: 14,
-                  fontWeight: 500,
-                  cursor: 'pointer',
-                  fontFamily: 'inherit',
-                  transition: 'all 0.2s',
-                  letterSpacing: '0.3px',
-                }}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-
-          {/* Calc body */}
-          <div
-            style={{
-              background: calcTab === 'pro' ? 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)' : 'var(--card)',
-              padding: '40px 48px',
-              transition: 'background 0.3s',
-            }}
-          >
-            <div
-              className="calc-header"
+            {showCalc ? 'Hide calculator' : 'Open pricing calculator'}
+            <span
               style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'flex-start',
-                marginBottom: 32,
-                gap: 24,
-                flexWrap: 'wrap',
+                display: 'inline-block',
+                transition: 'transform 0.3s',
+                transform: showCalc ? 'rotate(45deg)' : 'rotate(0deg)',
+                fontSize: 16,
+                lineHeight: 1,
               }}
             >
-              <div>
-                <h3
+              +
+            </span>
+          </button>
+        </div>
+        <div
+          style={{
+            maxHeight: showCalc ? 800 : 0,
+            overflow: 'hidden',
+            transition: 'max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+          }}
+        >
+          <div
+            style={{
+              background:
+                'linear-gradient(180deg, color-mix(in oklch, var(--primary) 6%, transparent) 0%, var(--card) 40%)',
+              border: '1px solid var(--border)',
+              borderRadius: 16,
+              overflow: 'hidden',
+            }}
+          >
+            {/* Tab switcher */}
+            <div style={{ display: 'flex', position: 'relative', borderBottom: '1px solid var(--border)' }}>
+              <div
+                style={{
+                  position: 'absolute',
+                  bottom: 0,
+                  left: calcTab === 'pro' ? '0%' : '50%',
+                  width: '50%',
+                  height: 2,
+                  background: 'var(--primary)',
+                  transition: 'left 0.3s',
+                  borderRadius: '1px 1px 0 0',
+                }}
+              />
+              {(['pro', 'biz'] as const).map((t) => (
+                <button
+                  key={t}
+                  onClick={() => {
+                    if (t === 'biz') setBizSeats(Math.min(proSeats, 200));
+                    else setProSeats(Math.min(bizSeats, 75));
+                    setCalcTab(t);
+                  }}
                   style={{
-                    fontSize: 18,
-                    fontWeight: 600,
-                    letterSpacing: '-0.4px',
-                    color: 'var(--foreground)',
-                    marginBottom: 6,
+                    flex: 1,
+                    padding: '16px 0',
+                    border: 'none',
+                    background: 'rgba(255,255,255,0.03)',
+                    color: calcTab === t ? 'var(--foreground)' : 'var(--muted-foreground)',
+                    fontSize: 14,
+                    fontWeight: 500,
+                    cursor: 'pointer',
+                    fontFamily: 'inherit',
+                    transition: 'color 0.2s',
+                    letterSpacing: '0.02em',
                   }}
                 >
-                  {calcTab === 'pro' ? 'Teams' : 'Business'} — see your exact price
-                </h3>
-                <p style={{ fontSize: 13, color: 'var(--muted-foreground)', maxWidth: 400, lineHeight: 1.6 }}>
-                  The more seats you add, the less you pay per seat. Click a tier or drag the slider.
-                </p>
-              </div>
-              <div style={{ textAlign: 'right', flexShrink: 0 }}>
+                  {t === 'pro' ? 'Teams' : 'Business'}
+                </button>
+              ))}
+            </div>
+
+            <div style={{ padding: '32px' }}>
+              {/* CSS Grid: two-column on desktop, stacked on mobile — see index.css .calc-output */}
+              <div className="calc-output">
                 <div
+                  className="calc-output-label"
                   style={{
                     fontSize: 11,
                     fontWeight: 600,
                     textTransform: 'uppercase',
-                    letterSpacing: '0.8px',
-                    color: calcTab === 'pro' ? 'var(--primary-muted)' : 'var(--muted-foreground)',
-                    marginBottom: 4,
+                    letterSpacing: '1px',
+                    fontFamily: 'var(--font-mono)',
+                    color: 'var(--muted-foreground)',
                   }}
                 >
-                  {isAnnual ? 'Effective per month (yearly)' : 'Total per month'}
+                  Monthly total
                 </div>
-                <div
+                <button
+                  className="calc-output-switch"
+                  onClick={() => setBilling((b) => (b === 'annual' ? 'monthly' : 'annual'))}
                   style={{
-                    fontSize: 42,
-                    fontWeight: 600,
-                    letterSpacing: '-1.5px',
-                    color: 'var(--foreground)',
-                    lineHeight: 1,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    padding: 0,
+                    fontFamily: 'inherit',
                   }}
                 >
-                  {fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}
-                </div>
-                <div style={{ fontSize: 12, color: 'var(--muted-foreground)', marginTop: 4 }}>
-                  {isAnnual
-                    ? `Billed as ${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr · you save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`
-                    : `${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr with yearly — save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`}
-                </div>
-              </div>
-            </div>
-
-            {/* Slider */}
-            <div style={{ marginBottom: 28 }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-                <span style={{ fontSize: 12, color: 'var(--muted-foreground)', fontWeight: 500 }}>Seats</span>
-                <strong style={{ fontSize: 14, color: 'var(--foreground)', fontWeight: 600 }}>
-                  {calcTab === 'pro' ? proSeats : bizSeats} seats
-                </strong>
-              </div>
-              <input
-                type="range"
-                min={2}
-                max={calcTab === 'pro' ? 75 : 200}
-                value={calcTab === 'pro' ? proSeats : bizSeats}
-                onChange={(e) =>
-                  calcTab === 'pro' ? setProSeats(parseInt(e.target.value)) : setBizSeats(parseInt(e.target.value))
-                }
-                className={calcTab === 'pro' ? 'pricing-slider' : 'pricing-slider-biz'}
-                style={{
-                  width: '100%',
-                  height: 5,
-                  borderRadius: 3,
-                  outline: 'none',
-                  WebkitAppearance: 'none',
-                  cursor: 'pointer',
-                  background: `linear-gradient(to right,${calcTab === 'pro' ? 'var(--primary)' : 'var(--foreground)'} 0%,${calcTab === 'pro' ? 'var(--primary)' : 'var(--foreground)'} ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,var(--input) ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%,var(--input) 100%)`,
-                }}
-              />
-            </div>
-
-            {/* Band cards */}
-            <div
-              className="band-grid"
-              style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, marginBottom: 24 }}
-            >
-              {(calcTab === 'pro' ? PRO_BANDS : BIZ_BANDS).map((band, i) => {
-                const acColor = calcTab === 'pro' ? 'var(--primary)' : 'var(--muted-foreground)';
-                const introRate = calcTab === 'pro' ? PRO_INTRO : BIZ_INTRO;
-                const dr = isAnnual ? Math.round(band.rate * ANNUAL_DISC) : band.rate;
-                const saving = Math.round((1 - band.rate / introRate) * 100);
-                const active = calcTab === 'pro' ? proBandIdx === i : bizBandIdx === i;
-                const rgbActive = calcTab === 'pro' ? '139,92,246' : '115,115,115';
-                return (
-                  <div
-                    key={i}
-                    onClick={() => (calcTab === 'pro' ? setProSeats(band.midpoint) : setBizSeats(band.midpoint))}
+                  <span
                     style={{
-                      background: active ? `rgba(${rgbActive},0.15)` : 'rgba(255,255,255,0.04)',
-                      border: `1px solid ${active ? acColor : 'rgba(255,255,255,0.06)'}`,
-                      boxShadow: active ? `0 0 16px rgba(${rgbActive},0.1)` : 'none',
-                      borderRadius: 8,
-                      padding: '14px 12px',
-                      textAlign: 'center',
-                      transition: 'all 0.25s',
-                      cursor: 'pointer',
+                      fontSize: 11,
+                      fontWeight: 600,
+                      letterSpacing: '1.5px',
+                      textTransform: 'uppercase',
+                      color: 'var(--muted-foreground)',
+                    }}
+                  >
+                    Annual
+                  </span>
+                  <div
+                    style={{
+                      width: 36,
+                      height: 20,
+                      borderRadius: 9999,
+                      background: isAnnual ? 'var(--primary)' : 'var(--input)',
+                      padding: 2,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: isAnnual ? 'flex-end' : 'flex-start',
+                      transition: 'background 0.2s',
+                      flexShrink: 0,
                     }}
                   >
                     <div
                       style={{
-                        fontSize: 10,
-                        fontWeight: 600,
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.5px',
-                        color: active ? 'var(--foreground)' : 'var(--muted-foreground)',
-                        marginBottom: 6,
+                        width: 16,
+                        height: 16,
+                        borderRadius: 9999,
+                        background: 'var(--primary-foreground)',
+                        boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+                        transition: 'transform 0.2s',
                       }}
-                    >
-                      {band.label}
-                    </div>
-                    <div
-                      style={{
-                        fontSize: 22,
-                        fontWeight: 600,
-                        letterSpacing: '-0.8px',
-                        color: 'var(--foreground)',
-                        lineHeight: 1,
-                        marginBottom: 3,
-                      }}
-                    >
-                      {fmt(dr)}
-                    </div>
-                    <div style={{ fontSize: 10, color: 'var(--muted-foreground)' }}>
-                      per seat / {isAnnual ? 'mo (yearly)' : 'mo'}
-                    </div>
-                    <div style={{ fontSize: 10, fontWeight: 500, color: C.green, marginTop: 5, minHeight: 14 }}>
-                      {saving === 0 ? 'introductory rate' : `${saving}% less than intro`}
-                    </div>
+                    />
                   </div>
-                );
-              })}
-            </div>
-
-            {/* Meta row */}
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                paddingTop: 20,
-                borderTop: '1px solid rgba(255,255,255,0.07)',
-                flexWrap: 'wrap',
-                gap: 12,
-              }}
-            >
-              <div style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
-                Per seat:{' '}
-                <strong style={{ color: 'var(--foreground)' }}>
-                  {fmt(calcTab === 'pro' ? proEffRate : bizEffRate)}
-                  {isAnnual ? ` (was ${fmt(calcTab === 'pro' ? proRate : bizRate)})` : ''}
-                </strong>
-              </div>
-              <div style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
-                Monthly:{' '}
-                <strong style={{ color: 'var(--foreground)' }}>
-                  {fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}
-                </strong>
-              </div>
-              <div style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
-                Yearly:{' '}
-                <strong style={{ color: 'var(--foreground)' }}>{fmt(calcTab === 'pro' ? proYearly : bizYearly)}</strong>
-                <span
+                </button>
+                <div
+                  className="calc-output-number"
                   style={{
-                    display: 'inline-block',
-                    background: C.greenDim,
-                    color: C.green,
-                    fontSize: 12,
-                    fontWeight: 500,
-                    padding: '2px 8px',
-                    borderRadius: 8,
-                    marginLeft: 6,
+                    fontSize: 56,
+                    fontWeight: 600,
+                    color: 'var(--foreground)',
+                    lineHeight: 1,
+                    letterSpacing: '-0.02em',
                   }}
                 >
-                  Save {fmt(calcTab === 'pro' ? proSave : bizSave)}
+                  <span style={{ fontSize: 32, opacity: 0.5, marginRight: 2 }}>$</span>
+                  {animatedTotal.toLocaleString('en-US')}
+                </div>
+                <div className="calc-output-rate">
+                  <div style={{ fontSize: 14, color: 'var(--muted-foreground)', lineHeight: 1 }}>
+                    {fmt(calcTab === 'pro' ? proEffRate : bizEffRate)}
+                    <span style={{ fontSize: 12, opacity: 0.6 }}>/seat</span>
+                  </div>
+                  <div style={{ fontSize: 12, color: 'var(--muted-foreground)', fontWeight: 500, lineHeight: 1 }}>
+                    Save {fmt(calcTab === 'pro' ? proSave : bizSave)}/yr on yearly
+                  </div>
+                </div>
+              </div>
+
+              {/* Divider */}
+              <div
+                style={{
+                  height: 1,
+                  background: 'linear-gradient(90deg, transparent, var(--border), transparent)',
+                  margin: '24px 0',
+                }}
+              />
+
+              {/* Seats row + slider */}
+              <div
+                style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 16 }}
+              >
+                <span style={{ fontSize: 14, color: 'var(--muted-foreground)', fontWeight: 500 }}>Seats</span>
+                <span style={{ fontSize: 28, fontWeight: 600, color: 'var(--foreground)' }}>
+                  {calcTab === 'pro' ? proSeats : bizSeats}
                 </span>
               </div>
-              <div style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
-                {calcTab === 'pro' ? (
-                  <>
-                    Need governance or SSO?{' '}
+              <div style={{ marginBottom: 24 }}>
+                <input
+                  type="range"
+                  min={2}
+                  max={calcTab === 'pro' ? 75 : 200}
+                  value={calcTab === 'pro' ? proSeats : bizSeats}
+                  onChange={(e) =>
+                    calcTab === 'pro' ? setProSeats(parseInt(e.target.value)) : setBizSeats(parseInt(e.target.value))
+                  }
+                  className={calcTab === 'pro' ? 'pricing-slider' : 'pricing-slider-biz'}
+                  style={{
+                    width: '100%',
+                    height: 6,
+                    borderRadius: 3,
+                    outline: 'none',
+                    WebkitAppearance: 'none',
+                    cursor: 'pointer',
+                    background: `linear-gradient(to right, var(--primary) 0%, var(--primary) ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%, var(--input) ${calcTab === 'pro' ? proSliderPct : bizSliderPct}%, var(--input) 100%)`,
+                  }}
+                />
+              </div>
+
+              {/* Tier pills */}
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 24 }}>
+                {(calcTab === 'pro' ? PRO_BANDS : BIZ_BANDS).map((band, i) => {
+                  const active = calcTab === 'pro' ? proBandIdx === i : bizBandIdx === i;
+                  return (
                     <button
-                      onClick={() => setCalcTab('biz')}
+                      key={i}
+                      onClick={() => (calcTab === 'pro' ? setProSeats(band.midpoint) : setBizSeats(band.midpoint))}
                       style={{
-                        background: 'none',
-                        border: 'none',
-                        color: 'var(--primary-muted)',
-                        fontWeight: 600,
+                        padding: '6px 14px',
+                        borderRadius: 999,
+                        fontSize: 13,
+                        fontWeight: 500,
                         cursor: 'pointer',
-                        fontSize: 12,
+                        border: `1px solid ${active ? 'var(--primary)' : 'var(--border)'}`,
+                        background: active ? 'color-mix(in oklch, var(--primary) 15%, transparent)' : 'transparent',
+                        color: active ? 'var(--primary-muted)' : 'var(--muted-foreground)',
                         fontFamily: 'inherit',
-                        padding: 0,
+                        transition: 'all 0.2s',
+                        whiteSpace: 'nowrap',
                       }}
                     >
-                      See Business pricing ↑
+                      {band.min}–{band.max} seats
                     </button>
-                  </>
-                ) : (
-                  <>
-                    Need 200+ seats?{' '}
-                    <a
-                      href="mailto:inbound@zephyr-cloud.io?subject=Enterprise"
-                      style={{ color: 'var(--foreground)', textDecoration: 'none', fontWeight: 600 }}
-                    >
-                      Talk to sales
-                    </a>{' '}
-                    — quoted same day.
-                  </>
-                )}
+                  );
+                })}
               </div>
-            </div>
 
-            {/* Checkout CTA */}
-            <div style={{ marginTop: 24, display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
+              {/* Divider */}
+              <div
+                style={{
+                  height: 1,
+                  background: 'linear-gradient(90deg, transparent, var(--border), transparent)',
+                  margin: '0 0 32px',
+                }}
+              />
+
+              {/* CTA */}
               <a
                 href="https://app.zephyr-cloud.io/"
                 target="_blank"
                 rel="noopener"
                 style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 10,
-                  padding: '8px 16px',
+                  display: 'block',
+                  width: '100%',
+                  textAlign: 'center',
+                  padding: '10px 24px',
                   borderRadius: 8,
-                  fontWeight: 500,
+                  background: 'var(--primary)',
+                  color: 'var(--primary-foreground)',
                   fontSize: 14,
+                  fontWeight: 500,
                   textDecoration: 'none',
-                  transition: 'all 0.2s',
-                  background: calcTab === 'pro' ? 'var(--primary)' : 'var(--secondary)',
-                  color: calcTab === 'pro' ? 'var(--primary-foreground)' : 'var(--secondary-foreground)',
+                  transition: 'opacity 0.2s',
                 }}
               >
                 Get started — {calcTab === 'pro' ? proSeats : bizSeats} seats ·{' '}
                 {fmt(calcTab === 'pro' ? proMonthly : bizMonthly)}/mo
               </a>
-              <span style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
+              <div style={{ textAlign: 'center', marginTop: 16, fontSize: 13, color: 'var(--muted-foreground)' }}>
                 No credit card required · free 30-day trial
-              </span>
+              </div>
             </div>
           </div>
         </div>
-        {/* end outer border wrapper */}
+        {/* end collapse wrapper */}
       </div>
 
-      {/* ── PROOF BAR ── */}
-      <div
-        style={{
-          borderTop: '1px solid var(--border)',
-          borderBottom: '1px solid var(--border)',
-          padding: '20px 40px',
-          display: 'flex',
-          justifyContent: 'center',
-          gap: 48,
-          flexWrap: 'wrap',
-          marginBottom: 80,
-        }}
-      >
-        {[
-          { n: '< 15', s: ' min', l: 'Avg. time to first deploy' },
-          { n: '15', s: '+', l: 'Bundler integrations' },
-          { n: '6', s: '+', l: 'Cloud integrations' },
-          { n: '15', s: '+', l: 'Countries' },
-          { n: 'SOC', s: ' 2', l: 'Compliant' },
-        ].map((s) => (
-          <div key={s.l} style={{ textAlign: 'center' }}>
-            <div
-              style={{
-                fontSize: 22,
-                fontWeight: 600,
-                letterSpacing: '-0.8px',
-                color: 'var(--foreground)',
-                lineHeight: 1,
-              }}
-            >
-              {s.n}
-              <span style={{ color: 'var(--primary-muted)' }}>{s.s}</span>
-            </div>
-            <div style={{ fontSize: 11, color: 'var(--muted-foreground)', marginTop: 3 }}>{s.l}</div>
-          </div>
-        ))}
-      </div>
+      {/* ── PROOF BAR ── (hidden) */}
 
       {/* ── SOCIAL PROOF ── */}
       <section style={{ maxWidth: 960, margin: '0 auto 80px', padding: '0 24px' }}>
         <div
           className="testimonial-card"
           style={{
-            background: 'var(--card)',
+            background: '#0d0d0d',
             border: '1px solid var(--border)',
-            borderRadius: 12,
-            padding: '28px 40px',
+            borderRadius: 16,
+            padding: '32px 40px',
             marginBottom: 16,
             display: 'flex',
             alignItems: 'center',
@@ -1164,7 +1090,7 @@ function PricingPage() {
                 "
               </span>
             </p>
-            <p style={{ fontSize: 12, color: 'var(--muted-foreground)', marginTop: 10 }}>
+            <p style={{ fontSize: 12, color: 'var(--muted-foreground)', marginTop: 8 }}>
               Engineering leadership ·{' '}
               <strong style={{ color: 'var(--foreground)', fontWeight: 600 }}>
                 Southern Glazer's Wine &amp; Spirits
@@ -1183,8 +1109,8 @@ function PricingPage() {
           style={{
             background: 'var(--card)',
             border: '1px solid var(--border)',
-            borderRadius: 12,
-            padding: '28px 40px',
+            borderRadius: 16,
+            padding: '32px 40px',
             display: 'grid',
             gridTemplateColumns: '1fr 1fr',
           }}
@@ -1249,8 +1175,8 @@ function PricingPage() {
       </section>
 
       {/* ── FEATURE TABLE ── */}
-      <section style={{ maxWidth: 1160, margin: '0 auto 80px', padding: '0 24px' }}>
-        <div style={{ marginBottom: 36 }}>
+      <section style={{ maxWidth: 1280, margin: '0 auto 80px', padding: '0 24px' }}>
+        <div style={{ marginBottom: 32 }}>
           <h2 className="text-4xl font-normal text-[#faf5ff]" style={{ marginBottom: 8 }}>
             Everything in the platform
           </h2>
@@ -1272,7 +1198,7 @@ function PricingPage() {
               type="button"
               onClick={() => setMobilePlan(key)}
               style={{
-                padding: '2px 12px',
+                padding: '4px 8px',
                 minHeight: 32,
                 borderRadius: 8,
                 fontSize: 12,
@@ -1316,12 +1242,12 @@ function PricingPage() {
                     key={label || 'feature'}
                     style={{
                       padding: '20px',
-                      fontSize: 14,
+                      fontSize: 16,
                       fontWeight: 500,
                       color: 'var(--foreground)',
                       textAlign: align as 'left' | 'center',
                       width: w,
-                      borderLeft: i > 0 ? '0.5px solid rgba(255,255,255,0.15)' : undefined,
+                      borderRight: i < 4 ? '1px solid rgba(255,255,255,0.15)' : undefined,
                     }}
                   >
                     {label}
@@ -1332,39 +1258,40 @@ function PricingPage() {
             <tbody>
               {(
                 [
-                  { g: 'Deployment' },
+                  { g: 'Deployment', sub: 'Preview environments, rollbacks, and pipeline control' },
                   { f: 'Cloud integrations', fr: '1', pr: 'All', bz: 'All', en: 'All' },
                   { f: 'Bundler plugins (15)', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'BYOC', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Instant rollbacks', fr: '—', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Tag / branch env', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Version history', fr: 'Limited', pr: '✓', bz: '✓', en: 'Custom' },
-                  { g: 'Module Federation Native', mfg: true },
+                  { g: 'Module Federation Native', sub: 'Built for MF teams, not bolted on', mfg: true },
                   { f: 'Environment Overrides', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
                   { f: 'Env Variables (no redeploy)', fr: '—', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Zephyr DevTools', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
                   { f: 'UML architecture map', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
                   { f: 'zephyr.dependencies', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
-                  { g: 'Teams & Access' },
+                  { g: 'Teams & Access', sub: 'Roles, seat management, and permissions' },
                   { f: 'Collaborators', fr: '—', pr: 'Up to 75', bz: 'Up to 200', en: 'Unlimited' },
                   { f: 'Per-team permissions', fr: '—', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Advanced roles', fr: '—', pr: '—', bz: '✓', en: '✓' },
                   { f: 'SSO / SAML', fr: '—', pr: '—', bz: '✓', en: '✓' },
                   { f: 'Approval workflows', fr: '—', pr: '—', bz: '✓', en: '✓' },
                   { f: 'Webhook integrations', fr: '—', pr: '—', bz: '✓', en: '✓' },
-                  { g: 'Security & Compliance' },
+                  { g: 'Security & Compliance', sub: 'Audit logs, certifications, and data governance' },
                   { f: 'Activity log', fr: '—', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Audit log retention', fr: '—', pr: '30 days', bz: '90 days', en: 'Custom' },
                   { f: 'Uptime SLA', fr: '—', pr: '—', bz: '99.9%', en: '99.99%' },
                   { f: 'SOC 2 compliance', fr: '—', pr: '—', bz: '—', en: '✓' },
                   { f: 'DPA', fr: '—', pr: '—', bz: '—', en: '✓' },
-                  { g: 'Support' },
+                  { g: 'Support', sub: 'Help when you need it' },
                   { f: 'Community support', fr: '✓', pr: '—', bz: '—', en: '—' },
                   { f: 'Email support', fr: '—', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Priority support', fr: '—', pr: '—', bz: '✓', en: '✓' },
                   { f: 'Dedicated CSM', fr: '—', pr: '—', bz: '—', en: '✓' },
                 ] as Array<{
                   g?: string;
+                  sub?: string;
                   mfg?: boolean;
                   f?: string;
                   fr?: string;
@@ -1380,17 +1307,29 @@ function PricingPage() {
                       <td
                         colSpan={5}
                         style={{
-                          background: 'rgba(255,255,255,0.05)',
-                          color: 'var(--foreground)',
-                          fontSize: 20,
-                          fontWeight: 500,
-                          padding: '16px 20px',
+                          background: 'transparent',
+                          borderTop: '1px solid rgba(255,255,255,0.1)',
+                          padding: '32px 24px 24px',
                         }}
                       >
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                          {row.g}
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: row.sub ? 8 : 0 }}>
+                          <span
+                            style={{
+                              fontSize: 24,
+                              fontWeight: 400,
+                              color: 'var(--foreground)',
+                              letterSpacing: '-0.3px',
+                            }}
+                          >
+                            {row.g}
+                          </span>
                           {row.mfg && <MfTag />}
                         </div>
+                        {row.sub && (
+                          <div style={{ fontSize: 16, color: 'var(--muted-foreground)', fontWeight: 400 }}>
+                            {row.sub}
+                          </div>
+                        )}
                       </td>
                     </tr>
                   );
@@ -1409,8 +1348,8 @@ function PricingPage() {
                     <td
                       style={{
                         padding: '16px 20px',
-                        borderTop: '0.5px solid rgba(255,255,255,0.15)',
-                        borderLeft: '0.5px solid rgba(255,255,255,0.15)',
+                        borderTop: '1px solid rgba(255,255,255,0.1)',
+                        borderLeft: '1px solid rgba(255,255,255,0.1)',
                         textAlign: 'center',
                         color,
                         minHeight: 60,
@@ -1427,7 +1366,7 @@ function PricingPage() {
                     <td
                       style={{
                         padding: '20px',
-                        borderTop: '0.5px solid rgba(255,255,255,0.15)',
+                        borderTop: '1px solid rgba(255,255,255,0.1)',
                         color: 'var(--foreground)',
                         fontWeight: 400,
                         fontSize: 14,
@@ -1435,7 +1374,7 @@ function PricingPage() {
                     >
                       {row.f}
                       {row.mf && (
-                        <span style={{ marginLeft: 6 }}>
+                        <span style={{ marginLeft: 8 }}>
                           <MfTag />
                         </span>
                       )}
@@ -1484,7 +1423,7 @@ function PricingPage() {
                     fontWeight: 500,
                     color: 'var(--foreground)',
                     textAlign: 'center',
-                    borderLeft: '0.5px solid rgba(255,255,255,0.15)',
+                    borderLeft: '1px solid rgba(255,255,255,0.1)',
                   }}
                 >
                   {mobilePlan === 'fr'
@@ -1500,39 +1439,40 @@ function PricingPage() {
             <tbody>
               {(
                 [
-                  { g: 'Deployment' },
+                  { g: 'Deployment', sub: 'Preview environments, rollbacks, and pipeline control' },
                   { f: 'Cloud integrations', fr: '1', pr: 'All', bz: 'All', en: 'All' },
                   { f: 'Bundler plugins (15)', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'BYOC', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Instant rollbacks', fr: '—', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Tag / branch env', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Version history', fr: 'Limited', pr: '✓', bz: '✓', en: 'Custom' },
-                  { g: 'Module Federation Native', mfg: true },
+                  { g: 'Module Federation Native', sub: 'Built for MF teams, not bolted on', mfg: true },
                   { f: 'Environment Overrides', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
                   { f: 'Env Variables (no redeploy)', fr: '—', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Zephyr DevTools', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
                   { f: 'UML architecture map', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
                   { f: 'zephyr.dependencies', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
-                  { g: 'Teams & Access' },
+                  { g: 'Teams & Access', sub: 'Roles, seat management, and permissions' },
                   { f: 'Collaborators', fr: '—', pr: 'Up to 75', bz: 'Up to 200', en: 'Unlimited' },
                   { f: 'Per-team permissions', fr: '—', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Advanced roles', fr: '—', pr: '—', bz: '✓', en: '✓' },
                   { f: 'SSO / SAML', fr: '—', pr: '—', bz: '✓', en: '✓' },
                   { f: 'Approval workflows', fr: '—', pr: '—', bz: '✓', en: '✓' },
                   { f: 'Webhook integrations', fr: '—', pr: '—', bz: '✓', en: '✓' },
-                  { g: 'Security & Compliance' },
+                  { g: 'Security & Compliance', sub: 'Audit logs, certifications, and data governance' },
                   { f: 'Activity log', fr: '—', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Audit log retention', fr: '—', pr: '30 days', bz: '90 days', en: 'Custom' },
                   { f: 'Uptime SLA', fr: '—', pr: '—', bz: '99.9%', en: '99.99%' },
                   { f: 'SOC 2 compliance', fr: '—', pr: '—', bz: '—', en: '✓' },
                   { f: 'DPA', fr: '—', pr: '—', bz: '—', en: '✓' },
-                  { g: 'Support' },
+                  { g: 'Support', sub: 'Help when you need it' },
                   { f: 'Community support', fr: '✓', pr: '—', bz: '—', en: '—' },
                   { f: 'Email support', fr: '—', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Priority support', fr: '—', pr: '—', bz: '✓', en: '✓' },
                   { f: 'Dedicated CSM', fr: '—', pr: '—', bz: '—', en: '✓' },
                 ] as Array<{
                   g?: string;
+                  sub?: string;
                   mfg?: boolean;
                   f?: string;
                   fr?: string;
@@ -1548,17 +1488,29 @@ function PricingPage() {
                       <td
                         colSpan={2}
                         style={{
-                          background: 'rgba(255,255,255,0.05)',
-                          color: 'var(--foreground)',
-                          fontSize: 16,
-                          fontWeight: 500,
-                          padding: '12px 16px',
+                          background: 'transparent',
+                          borderTop: '1px solid rgba(255,255,255,0.1)',
+                          padding: '24px 16px 16px',
                         }}
                       >
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                          {row.g}
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: row.sub ? 8 : 0 }}>
+                          <span
+                            style={{
+                              fontSize: 20,
+                              fontWeight: 400,
+                              color: 'var(--foreground)',
+                              letterSpacing: '-0.3px',
+                            }}
+                          >
+                            {row.g}
+                          </span>
                           {row.mfg && <MfTag />}
                         </div>
+                        {row.sub && (
+                          <div style={{ fontSize: 14, color: 'var(--muted-foreground)', fontWeight: 400 }}>
+                            {row.sub}
+                          </div>
+                        )}
                       </td>
                     </tr>
                   );
@@ -1577,8 +1529,8 @@ function PricingPage() {
                   <tr key={i} className={cn(path === 'nonmf' && row.mf && 'opacity-40')}>
                     <td
                       style={{
-                        padding: '14px 16px',
-                        borderTop: '0.5px solid rgba(255,255,255,0.15)',
+                        padding: '16px',
+                        borderTop: '1px solid rgba(255,255,255,0.1)',
                         color: 'var(--foreground)',
                         fontWeight: 400,
                         fontSize: 13,
@@ -1586,16 +1538,16 @@ function PricingPage() {
                     >
                       {row.f}
                       {row.mf && (
-                        <span style={{ marginLeft: 6 }}>
+                        <span style={{ marginLeft: 8 }}>
                           <MfTag />
                         </span>
                       )}
                     </td>
                     <td
                       style={{
-                        padding: '14px 16px',
-                        borderTop: '0.5px solid rgba(255,255,255,0.15)',
-                        borderLeft: '0.5px solid rgba(255,255,255,0.15)',
+                        padding: '16px',
+                        borderTop: '1px solid rgba(255,255,255,0.1)',
+                        borderLeft: '1px solid rgba(255,255,255,0.1)',
                         textAlign: 'center',
                         color,
                         fontSize: val === '✓' || val === '—' ? 15 : 12,
@@ -1612,10 +1564,221 @@ function PricingPage() {
         </div>
       </section>
 
+      {/* ── OVERAGES ── */}
+      <section style={{ maxWidth: 1280, margin: '0 auto 80px', padding: '0 24px' }}>
+        <div style={{ textAlign: 'center', marginBottom: 24 }}>
+          <button
+            onClick={() => setShowOverages((v) => !v)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '8px 16px',
+              borderRadius: 8,
+              background: 'var(--secondary)',
+              color: 'var(--secondary-foreground)',
+              border: 'none',
+              fontSize: 14,
+              fontWeight: 500,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              transition: 'opacity 0.2s',
+            }}
+          >
+            {showOverages ? 'Hide overage rates' : 'View overage rates'}
+            <span
+              style={{
+                display: 'inline-block',
+                transition: 'transform 0.3s',
+                transform: showOverages ? 'rotate(45deg)' : 'rotate(0deg)',
+                fontSize: 16,
+                lineHeight: 1,
+              }}
+            >
+              +
+            </span>
+          </button>
+        </div>
+        <div
+          style={{
+            maxHeight: showOverages ? 600 : 0,
+            overflow: 'hidden',
+            transition: 'max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+          }}
+        >
+          {/* Desktop */}
+          <div
+            className="feature-table-desktop"
+            style={{
+              overflowX: 'auto',
+              borderRadius: 16,
+              border: '1px solid rgba(255,255,255,0.1)',
+              background: '#0d0d0d',
+              boxShadow: '0 20px 60px rgba(0,0,0,0.28)',
+            }}
+          >
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14, minWidth: 680 }}>
+              <colgroup>
+                <col style={{ width: '28%' }} />
+                <col style={{ width: '18%' }} />
+                <col style={{ width: '18%' }} />
+                <col style={{ width: '18%' }} />
+                <col style={{ width: '18%' }} />
+              </colgroup>
+              <tbody>
+                {/* Group header */}
+                <tr>
+                  <td
+                    colSpan={5}
+                    style={{
+                      background: 'transparent',
+                      borderTop: '1px solid rgba(255,255,255,0.1)',
+                      padding: '32px 24px 24px',
+                    }}
+                  >
+                    <span
+                      style={{ fontSize: 24, fontWeight: 400, color: 'var(--foreground)', letterSpacing: '-0.3px' }}
+                    >
+                      Overages
+                    </span>
+                    <div style={{ fontSize: 16, color: 'var(--muted-foreground)', fontWeight: 400, marginTop: 8 }}>
+                      Transparent rates for usage beyond your plan limits.
+                    </div>
+                  </td>
+                </tr>
+                {[
+                  { f: 'Bandwidth', fr: '$40 / 100 GB', pr: '$30 / 100 GB', bz: '$25 / 100 GB', en: 'Custom' },
+                  { f: 'Storage', fr: '$10 / 50 GB', pr: '$7 / 50 GB', bz: '$5 / 50 GB', en: 'Custom' },
+                ].map((row, i) => {
+                  const cell = (val = '') => {
+                    const color =
+                      val === '—'
+                        ? 'var(--input)'
+                        : val === 'Custom'
+                          ? 'var(--primary-muted)'
+                          : 'var(--muted-foreground)';
+                    return (
+                      <td
+                        style={{
+                          padding: '16px 20px',
+                          borderTop: '1px solid rgba(255,255,255,0.1)',
+                          borderLeft: '1px solid rgba(255,255,255,0.1)',
+                          textAlign: 'center',
+                          color,
+                          fontSize: val === '—' ? 15 : 13,
+                          fontWeight: val === 'Custom' ? 600 : 400,
+                        }}
+                      >
+                        {val}
+                      </td>
+                    );
+                  };
+                  return (
+                    <tr key={i}>
+                      <td
+                        style={{
+                          padding: '20px',
+                          borderTop: '1px solid rgba(255,255,255,0.1)',
+                          color: 'var(--foreground)',
+                          fontWeight: 400,
+                          fontSize: 14,
+                        }}
+                      >
+                        {row.f}
+                      </td>
+                      {cell(row.fr)}
+                      {cell(row.pr)}
+                      {cell(row.bz)}
+                      {cell(row.en)}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile */}
+          <div
+            className="feature-table-mobile-table"
+            style={{
+              display: 'none',
+              borderRadius: 16,
+              border: '1px solid rgba(255,255,255,0.1)',
+              background: '#0d0d0d',
+              overflow: 'hidden',
+            }}
+          >
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+              <tbody>
+                <tr>
+                  <td
+                    colSpan={2}
+                    style={{
+                      background: 'transparent',
+                      borderTop: '1px solid rgba(255,255,255,0.1)',
+                      padding: '24px 16px 16px',
+                    }}
+                  >
+                    <span
+                      style={{ fontSize: 20, fontWeight: 400, color: 'var(--foreground)', letterSpacing: '-0.3px' }}
+                    >
+                      Overages
+                    </span>
+                    <div style={{ fontSize: 14, color: 'var(--muted-foreground)', fontWeight: 400, marginTop: 8 }}>
+                      Transparent rates for usage beyond your plan limits.
+                    </div>
+                  </td>
+                </tr>
+                {[
+                  { f: 'Bandwidth', fr: '$40 / 100 GB', pr: '$30 / 100 GB', bz: '$25 / 100 GB', en: 'Custom' },
+                  { f: 'Storage', fr: '$10 / 50 GB', pr: '$7 / 50 GB', bz: '$5 / 50 GB', en: 'Custom' },
+                ].map((row, i) => {
+                  const val = (row as Record<string, string>)[mobilePlan] ?? '';
+                  const color =
+                    val === '—'
+                      ? 'var(--input)'
+                      : val === 'Custom'
+                        ? 'var(--primary-muted)'
+                        : 'var(--muted-foreground)';
+                  return (
+                    <tr key={i}>
+                      <td
+                        style={{
+                          padding: '16px',
+                          borderTop: '1px solid rgba(255,255,255,0.1)',
+                          color: 'var(--foreground)',
+                          fontWeight: 400,
+                          fontSize: 13,
+                        }}
+                      >
+                        {row.f}
+                      </td>
+                      <td
+                        style={{
+                          padding: '16px',
+                          borderTop: '1px solid rgba(255,255,255,0.1)',
+                          borderLeft: '1px solid rgba(255,255,255,0.1)',
+                          textAlign: 'center',
+                          color,
+                          fontSize: val === '—' ? 15 : 12,
+                          fontWeight: val === 'Custom' ? 600 : 400,
+                        }}
+                      >
+                        {val}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
       {/* ── FAQ ── */}
       <section
         className="grid gap-8 pb-20 lg:grid-cols-[1fr_1fr]"
-        style={{ maxWidth: 1160, margin: '0 auto', padding: '0 24px 80px' }}
+        style={{ maxWidth: 1280, margin: '0 auto', padding: '0 24px 80px' }}
       >
         <div>
           <h2 className="max-w-md text-4xl font-normal text-foreground">Common questions</h2>
@@ -1642,13 +1805,13 @@ function PricingPage() {
 
       {/* ── FINAL CTA ── */}
       <section style={{ padding: '80px 24px 100px', borderTop: '1px solid var(--border)' }}>
-        <div style={{ maxWidth: 1160, margin: '0 auto' }}>
+        <div style={{ maxWidth: 1280, margin: '0 auto' }}>
           <div
             className="cta-card"
             style={{
               position: 'relative',
               overflow: 'hidden',
-              background: 'var(--card)',
+              background: '#0d0d0d',
               borderRadius: 16,
               padding: '56px 48px',
               display: 'flex',
@@ -1687,7 +1850,7 @@ function PricingPage() {
                 alignItems: 'center',
                 justifyContent: 'center',
                 background: 'rgba(255,255,255,0.92)',
-                color: '#0A0A0F',
+                color: 'var(--background)',
                 fontSize: 14,
                 fontWeight: 500,
                 padding: '8px 16px',
@@ -1706,7 +1869,7 @@ function PricingPage() {
 
       {/* Slider + responsive styles */}
       <style>{`
-        .pricing-slider::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:var(--primary); cursor:pointer; box-shadow:0 0 0 4px rgba(139,92,246,0.2); border:2px solid var(--foreground); }
+        .pricing-slider::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:var(--primary); cursor:pointer; box-shadow:0 0 0 4px color-mix(in oklch, var(--primary) 20%, transparent); border:2px solid var(--foreground); }
         .pricing-slider::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:var(--primary); cursor:pointer; border:2px solid var(--foreground); }
         .pricing-slider-biz::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:var(--foreground); cursor:pointer; box-shadow:0 0 0 4px rgba(255,255,255,0.1); border:2px solid var(--border); }
         .pricing-slider-biz::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:var(--foreground); cursor:pointer; border:2px solid var(--border); }
@@ -1732,20 +1895,20 @@ function PricingPage() {
         }
         @keyframes cta-gradient-shift {
           from { background-position: 100% 50%; }
-          to   { background-position: 70% 50%; }
+          to   { background-position: 80% 50%; }
         }
         @keyframes cta-gradient-mobile-shift {
           from { transform: translate(0px, 0px) scale(1); }
           to   { transform: translate(16px, -20px) scale(1.12); }
         }
         .cta-gradient {
-          background: linear-gradient(to left, oklch(0.541 0.247 293) 0%, oklch(0.541 0.247 293 / 0.85) 12%, oklch(0.38 0.18 285 / 0.45) 28%, oklch(0.22 0.07 270 / 0.06) 42%, transparent 52%);
-          background-size: 180% 100%;
+          background: linear-gradient(to left, var(--primary) 0%, color-mix(in oklch, var(--primary) 85%, transparent) 8%, color-mix(in oklch, var(--primary) 45%, transparent) 18%, color-mix(in oklch, var(--primary) 4%, transparent) 28%, transparent 35%);
+          background-size: 200% 100%;
           animation: cta-gradient-shift 5s ease-in-out infinite alternate;
         }
         @media (max-width: 600px) {
           .cta-gradient {
-            background: radial-gradient(ellipse 140% 90% at 10% 110%, oklch(0.541 0.247 293) 0%, oklch(0.48 0.22 290 / 0.85) 25%, oklch(0.35 0.16 283 / 0.5) 50%, transparent 72%) !important;
+            background: radial-gradient(ellipse 140% 90% at 10% 110%, var(--primary) 0%, color-mix(in oklch, var(--primary) 85%, transparent) 25%, color-mix(in oklch, var(--primary) 50%, transparent) 50%, transparent 72%) !important;
             background-size: 100% 100% !important;
             animation: cta-gradient-mobile-shift 5s ease-in-out infinite alternate !important;
           }
@@ -1770,7 +1933,7 @@ const featList = () => ({
   listStyle: 'none' as const,
   display: 'flex' as const,
   flexDirection: 'column' as const,
-  gap: 12,
+  gap: 16,
   margin: 0,
   padding: 0,
 });
@@ -1815,7 +1978,7 @@ function Cta({
 }
 function Fi({
   children,
-  c,
+  c: _c,
   dim,
   mf,
 }: {
@@ -1832,12 +1995,12 @@ function Fi({
         color: 'var(--muted-foreground)',
         display: 'flex',
         alignItems: 'flex-start',
-        gap: 9,
+        gap: 8,
         lineHeight: 1.45,
         opacity: dim ? 0.4 : 1,
       }}
     >
-      <Check size={16} style={{ color: ic, flexShrink: 0, marginTop: 1 }} />
+      <Check size={16} style={{ color: ic, flexShrink: 0 }} />
       <span style={{ flex: 1 }}>{children}</span>
       {mf && (
         <span style={{ flexShrink: 0, marginTop: 2 }}>
@@ -1847,9 +2010,6 @@ function Fi({
     </li>
   );
 }
-function Divider() {
-  return <li style={{ listStyle: 'none', height: 1, background: 'var(--accent)', margin: '4px 0' }} />;
-}
 function MfTag() {
   return (
     <span
@@ -1858,11 +2018,11 @@ function MfTag() {
         fontWeight: 600,
         textTransform: 'uppercase',
         letterSpacing: '0.5px',
-        background: 'rgba(124,58,237,0.15)',
+        background: 'color-mix(in oklch, var(--primary) 15%, transparent)',
         color: 'var(--primary-muted)',
-        border: `1px solid rgba(139,92,246,0.3)`,
-        padding: '1px 5px',
-        borderRadius: 3,
+        border: '1px solid color-mix(in oklch, var(--primary) 30%, transparent)',
+        padding: '2px 4px',
+        borderRadius: 4,
       }}
     >
       MF

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -68,6 +68,7 @@ function PricingPage() {
   const [bizSeats, setBizSeats] = useState(14);
   const [calcTab, setCalcTab] = useState<'pro' | 'biz'>('pro');
   const [openFaq, setOpenFaq] = useState<number | null>(null);
+  const [mobilePlan, setMobilePlan] = useState<'fr' | 'pr' | 'bz' | 'en'>('fr');
   const billingRef = useRef<HTMLDivElement>(null);
   const tiersRef = useRef<HTMLElement>(null);
   const panelsRef = useRef<HTMLDivElement>(null);
@@ -129,7 +130,7 @@ function PricingPage() {
     },
     {
       q: 'Can we pay by invoice or purchase order?',
-      a: "Yes. Business and Enterprise invoicing and PO billing are standard. Teams is credit card monthly or annually. If procurement requires an invoice for Teams, contact sales and we'll accommodate it.",
+      a: "Yes. Business and Enterprise invoicing and PO billing are standard. Teams is credit card monthly or yearly. If procurement requires an invoice for Teams, contact sales and we'll accommodate it.",
     },
     {
       q: 'What makes the MF-native features different?',
@@ -140,8 +141,8 @@ function PricingPage() {
       a: "Yes. DPAs are available on Enterprise. Zephyr is SOC 2 compliant and BYOC-first — your data stays in your own cloud. If you need a DPA as part of a POC, reach out and we'll accommodate it.",
     },
     {
-      q: 'Is there an annual discount?',
-      a: 'Yes — 15% off Teams and Business when billed annually. Toggle above to see annual pricing reflected live in the calculator.',
+      q: 'Is there a yearly discount?',
+      a: 'Yes — 15% off Teams and Business when billed yearly. Toggle above to see yearly pricing reflected live in the calculator.',
     },
   ];
 
@@ -433,7 +434,7 @@ function PricingPage() {
                 gap: 8,
               }}
             >
-              {mode === 'monthly' ? 'Monthly' : 'Annual'}
+              {mode === 'monthly' ? 'Monthly' : 'Yearly'}
               {mode === 'annual' && (
                 <span
                   style={{
@@ -464,7 +465,17 @@ function PricingPage() {
                 <p style={{ fontSize: 14, color: 'var(--muted-foreground)', lineHeight: 1.5 }}>1 seat</p>
               </div>
               <div>
-                <div style={{ fontSize: 12, color: 'transparent', marginBottom: 4, userSelect: 'none' }}>
+                <div
+                  style={{
+                    fontSize: 11,
+                    fontFamily: 'var(--font-mono)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '4px',
+                    color: 'transparent',
+                    marginBottom: 4,
+                    userSelect: 'none',
+                  }}
+                >
                   starting at
                 </div>
                 <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
@@ -481,7 +492,7 @@ function PricingPage() {
                     0
                   </span>
                   <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 6, fontWeight: 400 }}>
-                    / seat / mo
+                    /seat/mo.
                   </span>
                 </div>
               </div>
@@ -537,7 +548,18 @@ function PricingPage() {
                 </div>
               </div>
               <div>
-                <div style={{ fontSize: 12, color: 'var(--muted-foreground)', marginBottom: 4 }}>starting at</div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    fontFamily: 'var(--font-mono)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                    color: 'var(--muted-foreground)',
+                    marginBottom: 4,
+                  }}
+                >
+                  starting at
+                </div>
                 <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
                   <span style={{ fontSize: 22, fontWeight: 600, color: 'var(--foreground)', lineHeight: 1 }}>$</span>
                   <span
@@ -552,7 +574,7 @@ function PricingPage() {
                     {isAnnual ? Math.round(PRO_INTRO * ANNUAL_DISC) : PRO_INTRO}
                   </span>
                   <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 6, fontWeight: 400 }}>
-                    / seat / mo
+                    /seat/mo.
                   </span>
                 </div>
               </div>
@@ -603,7 +625,18 @@ function PricingPage() {
                 <p style={{ fontSize: 14, color: 'var(--muted-foreground)', lineHeight: 1.5 }}>2 – 200 seats</p>
               </div>
               <div>
-                <div style={{ fontSize: 12, color: 'var(--muted-foreground)', marginBottom: 4 }}>starting at</div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    fontFamily: 'var(--font-mono)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                    color: 'var(--muted-foreground)',
+                    marginBottom: 4,
+                  }}
+                >
+                  starting at
+                </div>
                 <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
                   <span style={{ fontSize: 22, fontWeight: 600, color: 'var(--foreground)', lineHeight: 1 }}>$</span>
                   <span
@@ -618,7 +651,7 @@ function PricingPage() {
                     {isAnnual ? Math.round(BIZ_INTRO * ANNUAL_DISC) : BIZ_INTRO}
                   </span>
                   <span style={{ fontSize: 14, color: 'var(--muted-foreground)', marginLeft: 6, fontWeight: 400 }}>
-                    / seat / mo
+                    /seat/mo.
                   </span>
                 </div>
               </div>
@@ -652,7 +685,17 @@ function PricingPage() {
                 <p style={{ fontSize: 14, color: 'var(--muted-foreground)', lineHeight: 1.5 }}>200+ seats</p>
               </div>
               <div>
-                <div style={{ fontSize: 12, color: 'transparent', marginBottom: 4, userSelect: 'none' }}>
+                <div
+                  style={{
+                    fontSize: 11,
+                    fontFamily: 'var(--font-mono)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '4px',
+                    color: 'transparent',
+                    marginBottom: 4,
+                    userSelect: 'none',
+                  }}
+                >
                   starting at
                 </div>
                 <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
@@ -667,9 +710,7 @@ function PricingPage() {
                   >
                     Custom
                   </span>
-                  <span style={{ fontSize: 14, color: 'transparent', marginLeft: 6, fontWeight: 400 }}>
-                    / seat / mo
-                  </span>
+                  <span style={{ fontSize: 14, color: 'transparent', marginLeft: 6, fontWeight: 400 }}>/seat/mo.</span>
                 </div>
               </div>
               <Cta href="mailto:inbound@zephyr-cloud.io?subject=Enterprise" v="secondary">
@@ -806,7 +847,7 @@ function PricingPage() {
                     marginBottom: 4,
                   }}
                 >
-                  {isAnnual ? 'Effective per month (annual)' : 'Total per month'}
+                  {isAnnual ? 'Effective per month (yearly)' : 'Total per month'}
                 </div>
                 <div
                   style={{
@@ -822,7 +863,7 @@ function PricingPage() {
                 <div style={{ fontSize: 12, color: 'var(--muted-foreground)', marginTop: 4 }}>
                   {isAnnual
                     ? `Billed as ${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr · you save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`
-                    : `${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr with annual — save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`}
+                    : `${fmt(calcTab === 'pro' ? proYearly : bizYearly)}/yr with yearly — save ${fmt(calcTab === 'pro' ? proSave : bizSave)}`}
                 </div>
               </div>
             </div>
@@ -908,7 +949,7 @@ function PricingPage() {
                       {fmt(dr)}
                     </div>
                     <div style={{ fontSize: 10, color: 'var(--muted-foreground)' }}>
-                      per seat / {isAnnual ? 'mo (annual)' : 'mo'}
+                      per seat / {isAnnual ? 'mo (yearly)' : 'mo'}
                     </div>
                     <div style={{ fontSize: 10, fontWeight: 500, color: C.green, marginTop: 5, minHeight: 14 }}>
                       {saving === 0 ? 'introductory rate' : `${saving}% less than intro`}
@@ -944,7 +985,7 @@ function PricingPage() {
                 </strong>
               </div>
               <div style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
-                Annual:{' '}
+                Yearly:{' '}
                 <strong style={{ color: 'var(--foreground)' }}>{fmt(calcTab === 'pro' ? proYearly : bizYearly)}</strong>
                 <span
                   style={{
@@ -1069,19 +1110,32 @@ function PricingPage() {
       {/* ── SOCIAL PROOF ── */}
       <section style={{ maxWidth: 960, margin: '0 auto 80px', padding: '0 24px' }}>
         <div
+          className="testimonial-card"
           style={{
             background: 'var(--card)',
             border: '1px solid var(--border)',
             borderRadius: 12,
             padding: '28px 40px',
-            display: 'grid',
-            gridTemplateColumns: '1fr auto',
-            gap: 32,
-            alignItems: 'center',
             marginBottom: 16,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 32,
           }}
         >
-          <div>
+          <div style={{ flex: 1 }}>
+            <span
+              style={{
+                display: 'block',
+                fontSize: 11,
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '1px',
+                color: 'var(--muted-foreground)',
+                marginBottom: 16,
+              }}
+            >
+              Enterprise customer
+            </span>
             <p
               style={{
                 fontSize: 16,
@@ -1117,33 +1171,12 @@ function PricingPage() {
               </strong>
             </p>
           </div>
-          <div
-            style={{
-              textAlign: 'right',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'flex-end',
-              gap: 8,
-              whiteSpace: 'nowrap',
-            }}
-          >
-            <img
-              src={sgwsLogo}
-              alt="Southern Glazer's Wine & Spirits"
-              style={{ height: 36, width: 'auto', opacity: 0.9 }}
-            />
-            <span
-              style={{
-                fontSize: 11,
-                fontWeight: 600,
-                textTransform: 'uppercase',
-                letterSpacing: '1px',
-                color: 'var(--muted-foreground)',
-              }}
-            >
-              Enterprise customer
-            </span>
-          </div>
+          <img
+            className="testimonial-logo"
+            src={sgwsLogo}
+            alt="Southern Glazer's Wine & Spirits"
+            style={{ height: 72, width: 72, objectFit: 'contain', opacity: 0.9, flexShrink: 0 }}
+          />
         </div>
         <div
           className="stats-grid"
@@ -1223,7 +1256,42 @@ function PricingPage() {
           </h2>
           <p style={{ fontSize: 14, color: 'var(--muted-foreground)' }}>Every feature, every tier.</p>
         </div>
+
+        {/* ── Mobile plan badge switcher ── */}
+        <div className="feature-table-badges" style={{ display: 'none', marginBottom: 16, gap: 8, flexWrap: 'wrap' }}>
+          {(
+            [
+              { key: 'fr', label: 'Free' },
+              { key: 'pr', label: 'Teams' },
+              { key: 'bz', label: 'Business' },
+              { key: 'en', label: 'Enterprise' },
+            ] as { key: 'fr' | 'pr' | 'bz' | 'en'; label: string }[]
+          ).map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setMobilePlan(key)}
+              style={{
+                padding: '2px 12px',
+                minHeight: 32,
+                borderRadius: 8,
+                fontSize: 12,
+                fontWeight: 500,
+                cursor: 'pointer',
+                border: 'none',
+                background: mobilePlan === key ? 'var(--primary)' : 'var(--secondary)',
+                color: mobilePlan === key ? 'var(--primary-foreground)' : 'var(--secondary-foreground)',
+                transition: 'background 0.15s, color 0.15s',
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* ── Desktop table ── */}
         <div
+          className="feature-table-desktop"
           style={{
             overflowX: 'auto',
             borderRadius: 16,
@@ -1382,6 +1450,166 @@ function PricingPage() {
             </tbody>
           </table>
         </div>
+
+        {/* ── Mobile table ── */}
+        <div
+          className="feature-table-mobile-table"
+          style={{
+            display: 'none',
+            borderRadius: 16,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: '#0d0d0d',
+            overflow: 'hidden',
+          }}
+        >
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+            <thead>
+              <tr style={{ background: 'black', borderBottom: '1px solid rgba(255,255,255,0.1)' }}>
+                <th
+                  style={{
+                    padding: '16px',
+                    fontSize: 14,
+                    fontWeight: 500,
+                    color: 'var(--foreground)',
+                    textAlign: 'left',
+                    width: '60%',
+                  }}
+                >
+                  Feature
+                </th>
+                <th
+                  style={{
+                    padding: '16px',
+                    fontSize: 14,
+                    fontWeight: 500,
+                    color: 'var(--foreground)',
+                    textAlign: 'center',
+                    borderLeft: '0.5px solid rgba(255,255,255,0.15)',
+                  }}
+                >
+                  {mobilePlan === 'fr'
+                    ? 'Free'
+                    : mobilePlan === 'pr'
+                      ? 'Teams'
+                      : mobilePlan === 'bz'
+                        ? 'Business'
+                        : 'Enterprise'}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {(
+                [
+                  { g: 'Deployment' },
+                  { f: 'Cloud integrations', fr: '1', pr: 'All', bz: 'All', en: 'All' },
+                  { f: 'Bundler plugins (15)', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'BYOC', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Instant rollbacks', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Tag / branch env', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Version history', fr: 'Limited', pr: '✓', bz: '✓', en: 'Custom' },
+                  { g: 'Module Federation Native', mfg: true },
+                  { f: 'Environment Overrides', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'Env Variables (no redeploy)', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Zephyr DevTools', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'UML architecture map', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'zephyr.dependencies', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { g: 'Teams & Access' },
+                  { f: 'Collaborators', fr: '—', pr: 'Up to 75', bz: 'Up to 200', en: 'Unlimited' },
+                  { f: 'Per-team permissions', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Advanced roles', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { f: 'SSO / SAML', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { f: 'Approval workflows', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { f: 'Webhook integrations', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { g: 'Security & Compliance' },
+                  { f: 'Activity log', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Audit log retention', fr: '—', pr: '30 days', bz: '90 days', en: 'Custom' },
+                  { f: 'Uptime SLA', fr: '—', pr: '—', bz: '99.9%', en: '99.99%' },
+                  { f: 'SOC 2 compliance', fr: '—', pr: '—', bz: '—', en: '✓' },
+                  { f: 'DPA', fr: '—', pr: '—', bz: '—', en: '✓' },
+                  { g: 'Support' },
+                  { f: 'Community support', fr: '✓', pr: '—', bz: '—', en: '—' },
+                  { f: 'Email support', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Priority support', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { f: 'Dedicated CSM', fr: '—', pr: '—', bz: '—', en: '✓' },
+                ] as Array<{
+                  g?: string;
+                  mfg?: boolean;
+                  f?: string;
+                  fr?: string;
+                  pr?: string;
+                  bz?: string;
+                  en?: string;
+                  mf?: boolean;
+                }>
+              ).map((row, i) => {
+                if (row.g)
+                  return (
+                    <tr key={i}>
+                      <td
+                        colSpan={2}
+                        style={{
+                          background: 'rgba(255,255,255,0.05)',
+                          color: 'var(--foreground)',
+                          fontSize: 16,
+                          fontWeight: 500,
+                          padding: '12px 16px',
+                        }}
+                      >
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                          {row.g}
+                          {row.mfg && <MfTag />}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                const val = row[mobilePlan] ?? '';
+                const color =
+                  val === '✓'
+                    ? 'var(--foreground)'
+                    : val === '—'
+                      ? 'var(--input)'
+                      : val === 'Limited'
+                        ? 'var(--muted-foreground)'
+                        : val === 'Custom' || val === 'Unlimited'
+                          ? 'var(--primary-muted)'
+                          : 'var(--muted-foreground)';
+                return (
+                  <tr key={i} className={cn(path === 'nonmf' && row.mf && 'opacity-40')}>
+                    <td
+                      style={{
+                        padding: '14px 16px',
+                        borderTop: '0.5px solid rgba(255,255,255,0.15)',
+                        color: 'var(--foreground)',
+                        fontWeight: 400,
+                        fontSize: 13,
+                      }}
+                    >
+                      {row.f}
+                      {row.mf && (
+                        <span style={{ marginLeft: 6 }}>
+                          <MfTag />
+                        </span>
+                      )}
+                    </td>
+                    <td
+                      style={{
+                        padding: '14px 16px',
+                        borderTop: '0.5px solid rgba(255,255,255,0.15)',
+                        borderLeft: '0.5px solid rgba(255,255,255,0.15)',
+                        textAlign: 'center',
+                        color,
+                        fontSize: val === '✓' || val === '—' ? 15 : 12,
+                        fontWeight: val === 'Limited' || val === 'Custom' ? 600 : 400,
+                      }}
+                    >
+                      {val}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       </section>
 
       {/* ── FAQ ── */}
@@ -1421,7 +1649,6 @@ function PricingPage() {
               position: 'relative',
               overflow: 'hidden',
               background: 'var(--card)',
-              border: '1px solid rgba(255,255,255,0.12)',
               borderRadius: 16,
               padding: '56px 48px',
               display: 'flex',
@@ -1431,15 +1658,7 @@ function PricingPage() {
             }}
           >
             {/* Purple gradient shader */}
-            <div
-              style={{
-                position: 'absolute',
-                inset: 0,
-                background:
-                  'linear-gradient(to left, oklch(0.541 0.247 293) 0%, oklch(0.541 0.247 293 / 0.85) 15%, oklch(0.38 0.18 285 / 0.45) 38%, oklch(0.22 0.07 270 / 0.1) 58%, transparent 72%)',
-                pointerEvents: 'none',
-              }}
-            />
+            <div className="cta-gradient" style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }} />
             {/* Text */}
             <div style={{ position: 'relative', minWidth: 0 }}>
               <h2
@@ -1504,6 +1723,32 @@ function PricingPage() {
           .stats-grid > div:last-child { padding-left: 0 !important; padding-top: 24px; }
           .cta-card { flex-direction: column !important; padding: 32px 24px !important; }
           .cta-card > a { width: 100% !important; }
+          .testimonial-card { flex-direction: column !important; align-items: flex-start !important; padding: 24px !important; }
+          .testimonial-card > div:first-child { order: 2; }
+          .testimonial-card .testimonial-logo { order: 1; align-self: flex-end; }
+          .feature-table-badges { display: flex !important; }
+          .feature-table-mobile-table { display: block !important; }
+          .feature-table-desktop { display: none !important; }
+        }
+        @keyframes cta-gradient-shift {
+          from { background-position: 100% 50%; }
+          to   { background-position: 70% 50%; }
+        }
+        @keyframes cta-gradient-mobile-shift {
+          from { transform: translate(0px, 0px) scale(1); }
+          to   { transform: translate(16px, -20px) scale(1.12); }
+        }
+        .cta-gradient {
+          background: linear-gradient(to left, oklch(0.541 0.247 293) 0%, oklch(0.541 0.247 293 / 0.85) 12%, oklch(0.38 0.18 285 / 0.45) 28%, oklch(0.22 0.07 270 / 0.06) 42%, transparent 52%);
+          background-size: 180% 100%;
+          animation: cta-gradient-shift 5s ease-in-out infinite alternate;
+        }
+        @media (max-width: 600px) {
+          .cta-gradient {
+            background: radial-gradient(ellipse 140% 90% at 10% 110%, oklch(0.541 0.247 293) 0%, oklch(0.48 0.22 290 / 0.85) 25%, oklch(0.35 0.16 283 / 0.5) 50%, transparent 72%) !important;
+            background-size: 100% 100% !important;
+            animation: cta-gradient-mobile-shift 5s ease-in-out infinite alternate !important;
+          }
         }
       `}</style>
     </div>
@@ -1558,7 +1803,6 @@ function Cta({
         fontSize: 14,
         fontWeight: 500,
         textDecoration: 'none',
-        marginBottom: 24,
         transition: 'all 0.2s',
         ...(v === 'primary'
           ? { background: 'var(--primary)', color: 'var(--primary-foreground)' }

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1,370 +1,1328 @@
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Tab } from '@/components/ui/tab';
-import akamai from '@/images/clouds/akamai_white.webp';
-import aws from '@/images/clouds/aws_white.webp';
-import cloudflare from '@/images/clouds/cloudflare_white.webp';
-import fastly from '@/images/clouds/fastly_white.webp';
-import vercel from '@/images/clouds/vercel_white.webp';
 import { cn } from '@/lib/utils';
 import { createFileRoute } from '@tanstack/react-router';
-import { Check, ChevronRight, Cloud, Infinity, Sparkles, Zap } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export const Route = createFileRoute('/pricing')({
   component: PricingPage,
 });
 
-const tiers = [
-  {
-    name: 'Personal',
-    id: 'personal',
-    href: 'https://app.zephyr-cloud.io/',
-    price: { monthly: 0, annually: 0 },
-    description: 'Perfect for side projects and personal experiments',
-    features: [
-      '1 editing user',
-      'Unlimited view-only users',
-      '∞ Preview environments',
-      '120GB bandwidth',
-      '50GB storage',
-      'Community support',
-      'BYOC (Bring Your Own Cloud)',
-      'Sub-second deployments',
-    ],
-    cta: 'Get Started',
-    mostPopular: false,
-  },
-  {
-    name: 'Team',
-    id: 'team',
-    href: 'https://app.zephyr-cloud.io/',
-    // TODO: Can we make this drop into the subscription page for team
-    price: { monthly: 19, annually: 16 },
-    description: 'For teams building and shipping together',
-    features: [
-      'Up to 10 editing users',
-      'Unlimited view-only users',
-      '∞ Preview environments',
-      '1TB bandwidth',
-      '100GB storage',
-      'Email support',
-      'BYOC (Bring Your Own Cloud)',
-      'Sub-second deployments',
-      'Team collaboration',
-    ],
-    cta: 'Start Collaborating',
-    mostPopular: true,
-  },
-  {
-    name: 'Business',
-    id: 'business',
-    href: 'https://app.zephyr-cloud.io/',
-    // TODO: Can we make this drop into the subscription page for business
-    price: { monthly: 99, annually: 84 },
-    description: 'For growing companies with production workloads',
-    features: [
-      'Up to 20 editing users',
-      'Unlimited view-only users',
-      '∞ Preview environments',
-      '1.5TB bandwidth',
-      '500GB storage',
-      'Private Slack/Discord channel',
-      'BYOC Poly-Cloud Support (Bring Your Own Cloud)',
-      'Sub-second deployments',
-      'Team collaboration',
-      'Priority support',
-      'Advanced analytics',
-      '99.9% uptime SLA',
-    ],
-    cta: 'Start Scaling',
-    mostPopular: false,
-  },
-  {
-    name: 'Enterprise',
-    id: 'enterprise',
-    href: 'mailto:inbound@zephyr-cloud.io?subject=Enterprise',
-    price: { monthly: null, annually: null },
-    description: 'For organizations with advanced security and support needs',
-    features: [
-      'Unlimited editing users',
-      'Unlimited view-only users',
-      '∞ Preview environments',
-      'Custom bandwidth',
-      'Custom storage',
-      'Dedicated support manager',
-      'Advanced analytics',
-      'Team collaboration',
-      '99.9% uptime SLA',
-      'On-Site Training & Onboarding',
-      'BYOC Poly-Cloud Support (Bring Your Own Cloud)',
-      'Sub-second deployments',
-      'SSO & advanced security',
-      'Custom SLAs',
-      'Professional services',
-    ],
-    cta: 'Contact Sales',
-    mostPopular: false,
-  },
-];
+// ── Design tokens ─────────────────────────────────────────────────────────────
+const C = {
+  black: '#0A0A0F',
+  black2: '#0F0F1A',
+  black3: '#111118',
+  border: '#1E1E2E',
+  borderLight: '#2D2D3A',
+  purple: '#8B5CF6',
+  purpleLight: '#A78BFA',
+  purpleDim: '#1A0F3A',
+  white: '#F5F4F0',
+  gray: '#9CA3AF',
+  grayDark: '#6B7280',
+  green: '#10B981',
+  greenDim: '#064E3B',
+  amber: '#E8A830',
+} as const;
 
+// ── Pro calculator bands ──────────────────────────────────────────────────────
+const PRO_BANDS = [
+  { min: 2, max: 10, rate: 39, midpoint: 6, label: '2 – 10 seats' },
+  { min: 11, max: 25, rate: 32, midpoint: 18, label: '11 – 25 seats' },
+  { min: 26, max: 50, rate: 27, midpoint: 38, label: '26 – 50 seats' },
+  { min: 51, max: 75, rate: 24, midpoint: 63, label: '51 – 75 seats' },
+];
+const INTRO_RATE = PRO_BANDS[0].rate;
+const ANNUAL_DISC = 0.85;
+
+function getRate(seats: number) {
+  return PRO_BANDS.find((b) => seats >= b.min && seats <= b.max)?.rate ?? 24;
+}
+function getBandIdx(seats: number) {
+  return PRO_BANDS.findIndex((b) => seats >= b.min && seats <= b.max);
+}
+function fmt(n: number) {
+  return '$' + Math.round(n).toLocaleString('en-US');
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
 function PricingPage() {
-  const [frequency, setFrequency] = useState<'monthly' | 'annually'>('monthly');
-  const isAnnual = frequency === 'annually';
-  const getTierButtonClassName = (tier: (typeof tiers)[number]) => {
-    switch (tier.id) {
-      case 'personal':
-        return 'border border-neutral-700 bg-neutral-900 text-white shadow-xs hover:border-neutral-500 hover:bg-neutral-800';
-      case 'team':
-        return 'border border-violet-500/70 bg-violet-600 text-white shadow-lg shadow-violet-900/30 hover:bg-violet-500 hover:border-violet-400';
-      case 'business':
-        return 'border border-neutral-700 bg-neutral-900 text-white shadow-xs hover:border-neutral-500 hover:bg-neutral-800';
-      case 'enterprise':
-        return 'border border-neutral-700 bg-neutral-900 text-white shadow-xs hover:border-neutral-500 hover:bg-neutral-800';
-      default:
-        return 'bg-neutral-500 hover:bg-neutral-600';
-    }
-  };
+  const [billing, setBilling] = useState<'monthly' | 'annual'>('monthly');
+  const [path, setPath] = useState<'mf' | 'nonmf' | null>(null);
+  const [seats, setSeats] = useState(2);
+  const [openFaq, setOpenFaq] = useState<number | null>(null);
+  const billingRef = useRef<HTMLDivElement>(null);
+  const isAnnual = billing === 'annual';
+
+  useEffect(() => {
+    const p = new URLSearchParams(window.location.search).get('for');
+    if (p === 'mf') setPath('mf');
+    else if (p === 'teams' || p === 'nonmf') setPath('nonmf');
+  }, []);
+
+  function selectPath(p: 'mf' | 'nonmf') {
+    setPath(p);
+    setTimeout(() => billingRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 400);
+  }
+
+  // Calculator
+  const rate = getRate(seats);
+  const effRate = isAnnual ? Math.round(rate * ANNUAL_DISC * 100) / 100 : rate;
+  const moTotal = Math.round(seats * effRate);
+  const yrTotal = Math.round(seats * rate * 12 * ANNUAL_DISC);
+  const yrFull = seats * rate * 12;
+  const yrSave = Math.round(yrFull - yrTotal);
+  const bandIdx = getBandIdx(seats);
+  const sliderPct = ((seats - 2) / 73) * 100;
+
+  const faqs = [
+    {
+      q: 'Do I need Module Federation to get value from Zephyr?',
+      a: 'No. BYOC, instant rollbacks, and environment variables without redeploying are available on Pro — none of them require Module Federation. MF-native features are additive. Many teams start without MF and adopt it later.',
+    },
+    {
+      q: 'How does Pro pricing work as the team grows?',
+      a: "Pro starts at $39/seat for 2–10 seats. At 11–25 seats the rate drops to $32/seat. At 26–50 it's $27/seat. At 51–75 it's $24/seat — 38% less than the intro rate. Use the calculator to see your exact price.",
+    },
+    {
+      q: 'What happens when we hit 76 seats?',
+      a: 'You move to Enterprise — custom pricing, quoted same day, no RFP required. Enterprise is volume-based so the per-seat rate keeps decreasing. No cliff, no surprise.',
+    },
+    {
+      q: 'What is BYOC — and what does it mean for our data?',
+      a: 'Bring Your Own Cloud. Deployments go to your own infrastructure — Cloudflare, AWS, Fastly, Akamai, or Vercel. Your data never leaves your cloud. This answers most data residency and DPA questions before your security team asks them.',
+    },
+    {
+      q: 'Are there overage charges for bandwidth or storage?',
+      a: "Pro includes 1.5TB bandwidth and 500GB storage. We'll reach out before charging anything — no automatic overage fees. Enterprise limits are agreed upfront so procurement always knows the ceiling.",
+    },
+    {
+      q: 'Can we pay by invoice or purchase order?',
+      a: "Yes. Enterprise invoicing and PO billing are standard. Pro is credit card monthly or annually. If procurement requires an invoice for Pro, contact sales and we'll accommodate it.",
+    },
+    {
+      q: 'What makes the MF-native features different?',
+      a: "They were built by the team that created Module Federation. Environment Overrides, DevTools, UML, and zephyr.dependencies aren't integrations — they require authorship-level understanding of MF. No other platform offers these.",
+    },
+    {
+      q: "Is a data processing agreement available? We're in a regulated sector.",
+      a: "Yes. DPAs are available on Enterprise. Zephyr is SOC 2 compliant and BYOC-first — your data stays in your own cloud. If you need a DPA as part of a POC, reach out and we'll accommodate it.",
+    },
+    {
+      q: 'Is there an annual discount?',
+      a: 'Yes — 15% off Pro when billed annually. Toggle above to see annual pricing reflected live in the calculator.',
+    },
+  ];
 
   return (
-    <div className="container mx-auto px-4 py-16 max-w-7xl">
-      {/* Hero Section */}
-      <div className="text-center mb-8">
-        <h1 className="text-5xl font-medium leading-tighter mb-4 text-white">Pricing that scales with your team</h1>
-        <p className="text-xl text-neutral-400 mb-1 max-w-2xl mx-auto">Start free and scale as you grow.</p>
-      </div>
-
-      {/* Key Features Banner */}
-      <div className="bg-gradient-to-r from-violet-900/20 to-violet-700/20 border border-violet-700/30 rounded-lg p-6 mb-12">
-        <div className="flex flex-wrap items-center justify-center gap-6 text-sm">
-          <div className="flex items-center gap-2">
-            <Infinity className="h-4 w-4 text-violet-500" />
-            <span>No build minutes</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Zap className="h-4 w-4 text-violet-500" />
-            <span>Sub-second deployments</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Cloud className="h-4 w-4 text-violet-500" />
-            <span>Bring Your Own Cloud (BYOC)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Sparkles className="h-4 w-4 text-violet-500" />
-            <span>Unlimited preview environments</span>
-          </div>
+    <div style={{ background: C.black, color: C.white, lineHeight: 1.6 }}>
+      {/* ── HERO ── */}
+      <section style={{ textAlign: 'center', padding: '72px 40px 48px', maxWidth: 760, margin: '0 auto' }}>
+        <div
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 8,
+            background: C.purpleDim,
+            border: '1px solid rgba(139,92,246,0.3)',
+            color: C.purpleLight,
+            fontSize: 11,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '1.2px',
+            padding: '5px 14px',
+            borderRadius: 20,
+            marginBottom: 24,
+          }}
+        >
+          ● Pricing
         </div>
-      </div>
+        <h1
+          style={{
+            fontSize: 'clamp(32px, 5vw, 52px)',
+            fontWeight: 900,
+            letterSpacing: '-1.5px',
+            lineHeight: 1.08,
+            marginBottom: 18,
+          }}
+        >
+          Deployment that fits
+          <br />
+          where your team <em style={{ fontStyle: 'normal', color: C.purpleLight }}>actually is.</em>
+        </h1>
+        <p style={{ fontSize: 16, color: C.gray, maxWidth: 520, margin: '0 auto 48px', lineHeight: 1.75 }}>
+          Whether you're running Module Federation or not, Zephyr meets you there — and the price goes down as your team
+          scales up.
+        </p>
 
-      {/* Billing Toggle */}
-      <div className="p-6 mb-6">
-        <div className="mx-auto flex w-fit rounded-full bg-neutral-900 p-1">
-          <Tab text="monthly" selected={frequency === 'monthly'} setSelected={() => setFrequency('monthly')} />
-          <Tab
-            text="annually"
-            selected={frequency === 'annually'}
-            setSelected={() => setFrequency('annually')}
-            discount={true}
-          />
-        </div>
-      </div>
-      {/* Pricing Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
-        {tiers.map((tier) => (
-          <Card
-            key={tier.id}
-            className={cn(
-              'relative flex flex-col',
-              tier.mostPopular && 'border-violet-700 shadow-lg shadow-violet-700/20',
-            )}
-          >
-            {tier.mostPopular && (
-              <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-                <span className="bg-violet-600 text-white text-xs font-semibold px-3 py-1 rounded-full">
-                  Most Popular
-                </span>
-              </div>
-            )}
-
-            <CardHeader>
-              <CardTitle className="text-2xl">{tier.name}</CardTitle>
-              <CardDescription className="text-sm">{tier.description}</CardDescription>
-
-              <div className="mt-4">
-                {tier.price.monthly !== null ? (
-                  <div className="flex items-baseline gap-1">
-                    <span className="text-4xl font-bold">${isAnnual ? tier.price.annually : tier.price.monthly}</span>
-                    <span className="text-neutral-400">/user/month</span>
-                  </div>
-                ) : (
-                  <div className="text-3xl font-bold">Custom pricing</div>
-                )}
-              </div>
-            </CardHeader>
-
-            <CardContent className="flex-1">
-              <ul className="space-y-3">
-                {tier.features.map((feature, i) => (
-                  <li key={i} className="flex items-start gap-2">
-                    <Check className="h-4 w-4 text-violet-500 mt-0.5 shrink-0" />
-                    <span className="text-sm text-neutral-300">{feature}</span>
-                  </li>
-                ))}
-              </ul>
-            </CardContent>
-
-            <CardFooter>
-              <Button
-                className={cn(
-                  'w-full font-semibold transition-transform duration-200 hover:-translate-y-0.5',
-                  getTierButtonClassName(tier),
-                )}
-                asChild
+        {/* Path selector */}
+        <div style={{ display: 'flex', gap: 14, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 16 }}>
+          {(
+            [
+              {
+                id: 'mf',
+                icon: '⚡',
+                title: 'We use Module Federation',
+                sub: "We're running MF and need a proper deployment platform built around it.",
+              },
+              {
+                id: 'nonmf',
+                icon: '🚀',
+                title: "We don't use MF yet",
+                sub: 'We want cloud-agnostic deployments, better rollbacks, and a faster pipeline.',
+              },
+            ] as const
+          ).map(({ id, icon, title, sub }) => {
+            const active = path === id;
+            const isMf = id === 'mf';
+            const activeColor = isMf ? C.purple : C.green;
+            return (
+              <div
+                key={id}
+                onClick={() => selectPath(id)}
+                style={{
+                  background: C.black2,
+                  borderRadius: 12,
+                  padding: '22px 28px',
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                  maxWidth: 280,
+                  width: '100%',
+                  position: 'relative',
+                  overflow: 'hidden',
+                  transition: 'all 0.25s',
+                  border: `2px solid ${active ? activeColor : C.border}`,
+                  boxShadow: active
+                    ? `0 0 0 1px ${activeColor}, 0 8px 32px ${isMf ? 'rgba(139,92,246,0.15)' : 'rgba(16,185,129,0.12)'}`
+                    : 'none',
+                  transform: active ? 'translateY(-2px)' : 'none',
+                }}
               >
-                <a href={tier.href} target="_blank">
-                  {tier.cta}
-                  <ChevronRight className="ml-1 h-4 w-4" />
-                </a>
-              </Button>
-            </CardFooter>
-          </Card>
-        ))}
+                {active && (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      top: 14,
+                      right: 14,
+                      width: 20,
+                      height: 20,
+                      borderRadius: '50%',
+                      background: activeColor,
+                      color: 'white',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: 10,
+                      fontWeight: 900,
+                    }}
+                  >
+                    ✓
+                  </div>
+                )}
+                <div style={{ fontSize: 22, marginBottom: 10 }}>{icon}</div>
+                <div
+                  style={{ fontSize: 15, fontWeight: 800, color: C.white, marginBottom: 5, letterSpacing: '-0.3px' }}
+                >
+                  {title}
+                </div>
+                <div style={{ fontSize: 12, color: C.gray, lineHeight: 1.5 }}>{sub}</div>
+              </div>
+            );
+          })}
+        </div>
+        {!path && (
+          <p style={{ fontSize: 12, color: C.grayDark }}>
+            Select your situation to see what matters most to your team.
+          </p>
+        )}
+      </section>
+
+      {/* ── VALUE PANELS ── */}
+      {(['mf', 'nonmf'] as const).map((panelId) => {
+        const isMf = panelId === 'mf';
+        const visible = path === panelId;
+        const accent = isMf ? C.purpleLight : C.green;
+        const pains = isMf
+          ? [
+              {
+                problem:
+                  "CI is a bottleneck for critical deploys. You're waiting on pipelines to push a config change.",
+                solution: 'Environment Overrides',
+                mf: true,
+              },
+              {
+                problem:
+                  'Engineers maintain internal tooling to develop locally against MFEs. It eats sprint capacity every cycle.',
+                solution: 'Zephyr DevTools',
+                mf: true,
+              },
+              {
+                problem:
+                  'No visibility into who deployed what across remotes. Audit and compliance reviews are painful.',
+                solution: 'Audit logs + Activity',
+                mf: false,
+              },
+            ]
+          : [
+              {
+                problem: "You're locked to Vercel or Netlify. Migrating or going multi-cloud is a project in itself.",
+                solution: 'BYOC — bring your own cloud',
+                mf: false,
+              },
+              {
+                problem:
+                  "Rollbacks mean redeploying. When something breaks in production, you're waiting on the pipeline.",
+                solution: 'Instant rollbacks, any cloud',
+                mf: false,
+              },
+              {
+                problem:
+                  'Changing an environment variable triggers a full redeploy. Small config changes block shipping.',
+                solution: 'Env Variables, no redeploy',
+                mf: false,
+              },
+            ];
+        return (
+          <div
+            key={panelId}
+            style={{
+              maxWidth: 960,
+              padding: '0 24px',
+              overflow: 'hidden',
+              maxHeight: visible ? 600 : 0,
+              opacity: visible ? 1 : 0,
+              marginLeft: 'auto',
+              marginRight: 'auto',
+              marginTop: visible ? 48 : 0,
+              marginBottom: visible ? 56 : 0,
+              transition: 'max-height 0.5s ease, opacity 0.4s ease, margin 0.4s ease',
+            }}
+          >
+            <div
+              style={{
+                borderRadius: 14,
+                padding: '40px 48px',
+                background: isMf
+                  ? 'linear-gradient(135deg,#1A0F3A 0%,#0F0F1A 70%)'
+                  : 'linear-gradient(135deg,#062A1F 0%,#0F0F1A 70%)',
+                border: `1px solid ${isMf ? 'rgba(139,92,246,0.3)' : 'rgba(16,185,129,0.25)'}`,
+              }}
+            >
+              <div style={{ marginBottom: 32 }}>
+                <div
+                  style={{
+                    fontSize: 10,
+                    fontWeight: 700,
+                    textTransform: 'uppercase',
+                    letterSpacing: '1.2px',
+                    color: accent,
+                    marginBottom: 10,
+                  }}
+                >
+                  {isMf ? 'For Module Federation teams' : 'For teams not yet on Module Federation'}
+                </div>
+                <h2 style={{ fontSize: 26, fontWeight: 900, letterSpacing: '-0.6px', lineHeight: 1.2, color: C.white }}>
+                  {isMf ? (
+                    <>
+                      You adopted MF. Now you need the platform{' '}
+                      <em style={{ fontStyle: 'normal', color: accent }}>built around it.</em>
+                    </>
+                  ) : (
+                    <>
+                      Your deployment stack shouldn't be{' '}
+                      <em style={{ fontStyle: 'normal', color: accent }}>owned by your cloud provider.</em>
+                    </>
+                  )}
+                </h2>
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
+                {pains.map((item, i) => (
+                  <div
+                    key={i}
+                    style={{
+                      background: 'rgba(255,255,255,0.04)',
+                      borderRadius: 10,
+                      padding: '18px 16px',
+                      border: '1px solid rgba(255,255,255,0.06)',
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: 11,
+                        color: C.grayDark,
+                        marginBottom: 6,
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}
+                    >
+                      The problem
+                    </div>
+                    <p style={{ fontSize: 13, color: C.gray, lineHeight: 1.5, marginBottom: 10 }}>{item.problem}</p>
+                    <div
+                      style={{
+                        fontSize: 12,
+                        fontWeight: 700,
+                        color: accent,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 6,
+                      }}
+                    >
+                      → {item.solution}
+                      {item.mf && <MfTag />}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+
+      {/* ── BILLING TOGGLE ── */}
+      <div ref={billingRef} style={{ textAlign: 'center', padding: '0 24px 48px' }}>
+        <div
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            background: C.black3,
+            border: `1px solid ${C.border}`,
+            borderRadius: 40,
+            padding: 4,
+          }}
+        >
+          {(['monthly', 'annual'] as const).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => setBilling(mode)}
+              style={{
+                background: billing === mode ? C.purple : 'none',
+                border: 'none',
+                color: billing === mode ? 'white' : C.gray,
+                fontSize: 13,
+                fontWeight: 600,
+                padding: '7px 18px',
+                borderRadius: 30,
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+                fontFamily: 'inherit',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              {mode === 'monthly' ? 'Monthly' : 'Annual'}
+              {mode === 'annual' && (
+                <span
+                  style={{
+                    background: C.greenDim,
+                    color: C.green,
+                    fontSize: 10,
+                    fontWeight: 700,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.5px',
+                    padding: '2px 7px',
+                    borderRadius: 8,
+                  }}
+                >
+                  Save 15%
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
       </div>
 
-      {/* BYOC Feature Section */}
-      <div className="bg-neutral-900 rounded-lg p-8 mb-16">
-        <div className="grid lg:grid-cols-2 gap-8 items-center">
-          <div>
-            <h2 className="text-3xl font-bold mb-4">
-              <Cloud className="inline-block h-8 w-8 text-foreground mr-2" />
-              Bring Your Own Cloud (BYOC)
-            </h2>
-            <p className="text-neutral-400 mb-6">
-              Deploy to your Cloudflare, Akamai, Vercel, or any of our supported cloud providers. Switch clouds
-              instantly, deploy to multiple clouds or multiple accounts on a cloud simultaneously.
-              <br />
-              With BYOC, you maintain complete control over your infrastructure and costs.
+      {/* ── TIER CARDS ── */}
+      <section style={{ maxWidth: 960, margin: '0 auto', padding: '0 24px 80px' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16, alignItems: 'start' }}>
+          {/* FREE */}
+          <div style={card()}>
+            <TierName>Free</TierName>
+            <div style={amt()}>$0</div>
+            <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>forever</div>
+            <TierSeats>1 seat · no credit card required</TierSeats>
+            <p style={desc()}>
+              For individuals exploring Zephyr. One cloud integration, all bundlers, and tag-based environments — free
+              forever.
             </p>
-            <ul className="space-y-2">
-              <li className="flex items-center gap-2">
-                <Check className="h-5 w-5 text-violet-500" />
-                <span>No vendor lock-in. Ever.</span>
-              </li>
-              <li className="flex items-center gap-2">
-                <Check className="h-5 w-5 text-violet-500" />
-                <span>Deploy to any cloud provider</span>
-              </li>
-              <li className="flex items-center gap-2">
-                <Check className="h-5 w-5 text-violet-500" />
-                <span>Switch clouds with one click</span>
-              </li>
-              <li className="flex items-center gap-2">
-                <Check className="h-5 w-5 text-violet-500" />
-                <span>Multi-cloud deployments</span>
-              </li>
-              <li className="flex items-center gap-2">
-                <Check className="h-5 w-5 text-violet-500" />
-                <span>Your security, your compliance</span>
-              </li>
+            <Cta href="https://app.zephyr-cloud.io/" v="secondary">
+              Get started free
+            </Cta>
+            <ul style={featList()}>
+              {[
+                '1 cloud integration',
+                'All 15 bundler plugins',
+                'Basic version history',
+                'Tag / branch env creation',
+                '120GB bandwidth · 50GB storage',
+              ].map((f) => (
+                <Fi key={f} c="green">
+                  {f}
+                </Fi>
+              ))}
             </ul>
           </div>
-          <div className="bg-neutral-800 rounded-lg p-6">
-            <div className="space-y-4">
-              <div className="text-sm text-neutral-400 text-center">Deploy to your favorite cloud providers</div>
-              <div className="grid grid-cols-3 gap-4">
-                <div className="flex items-center justify-center p-3">
-                  <img
-                    src={cloudflare}
-                    alt="Cloudflare"
-                    className="h-8 w-auto opacity-80 hover:opacity-100 transition-opacity"
-                  />
-                </div>
-                <div className="flex items-center justify-center p-3">
-                  <img
-                    src={fastly}
-                    alt="Fastly"
-                    className="h-8 w-auto opacity-80 hover:opacity-100 transition-opacity"
-                  />
-                </div>
-                <div className="flex items-center justify-center p-3">
-                  <img
-                    src={akamai}
-                    alt="Akamai"
-                    className="h-8 w-auto opacity-80 hover:opacity-100 transition-opacity"
-                  />
-                </div>
-                <div className="flex items-center justify-center p-3">
-                  <img src={aws} alt="AWS" className="h-8 w-auto opacity-50 grayscale" title="Coming Soon" />
-                </div>
-                <div className="flex items-center justify-center p-3">
-                  <img src={vercel} alt="Vercel" className="h-8 w-auto opacity-50 grayscale" title="Coming Soon" />
-                </div>
+
+          {/* PRO */}
+          <div
+            style={{
+              ...card(),
+              background: 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)',
+              border: `1px solid ${C.purple}`,
+              boxShadow: '0 0 48px rgba(139,92,246,0.12)',
+            }}
+          >
+            <div
+              style={{
+                position: 'absolute',
+                top: -12,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                background: C.purple,
+                color: 'white',
+                fontSize: 10,
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.8px',
+                padding: '4px 14px',
+                borderRadius: 10,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Most Popular
+            </div>
+            <TierName purple>Pro</TierName>
+            <div style={{ fontSize: 13, color: C.grayDark, fontWeight: 500, marginBottom: 2 }}>starting at</div>
+            <div style={amt()}>{isAnnual ? fmt(Math.round(INTRO_RATE * ANNUAL_DISC)) : fmt(INTRO_RATE)}</div>
+            <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>
+              per seat / month ·{' '}
+              <a href="#pro-calc" style={{ color: C.purpleLight, textDecoration: 'none', fontWeight: 600 }}>
+                use the calculator ↓
+              </a>
+            </div>
+            <TierSeats>2 – 75 seats · costs decrease as your team scales</TierSeats>
+            <p style={desc()}>
+              The full platform. BYOC, MF-native features, per-team permissions, and audit logs — everything a scaling
+              engineering team needs.
+            </p>
+            <Cta href="https://app.zephyr-cloud.io/" v="primary">
+              Start free 30-day trial
+            </Cta>
+            <div
+              style={{
+                fontSize: 11,
+                color: C.grayDark,
+                textAlign: 'center',
+                marginTop: -16,
+                marginBottom: 12,
+                lineHeight: 1.5,
+              }}
+            >
+              No credit card required · full Pro access · keep your data after trial
+            </div>
+            <div style={{ fontSize: 12, color: C.grayDark, marginBottom: 16 }}>Up and running in under 15 minutes.</div>
+            <ul style={featList()}>
+              <Fi c="green">
+                <strong style={{ color: C.white }}>BYOC</strong> — any cloud
+              </Fi>
+              <Fi c="green">All cloud integrations</Fi>
+              <Fi c="green">Instant rollbacks</Fi>
+              <Fi c="green">Full version history</Fi>
+              <Divider />
+              <Fi c="purple" dim={path === 'nonmf'}>
+                <strong style={{ color: C.white }}>Environment Overrides</strong> <MfTag />
+              </Fi>
+              <Fi c="purple">
+                <strong style={{ color: C.white }}>Env Variables</strong> — no redeploy
+              </Fi>
+              <Fi c="purple" dim={path === 'nonmf'}>
+                <strong style={{ color: C.white }}>Zephyr DevTools</strong> <MfTag />
+              </Fi>
+              <Fi c="purple" dim={path === 'nonmf'}>
+                <strong style={{ color: C.white }}>UML architecture map</strong> <MfTag />
+              </Fi>
+              <Fi c="purple" dim={path === 'nonmf'}>
+                <strong style={{ color: C.white }}>zephyr.dependencies</strong> <MfTag />
+              </Fi>
+              <Divider />
+              <Fi c="green">Per-team deploy permissions</Fi>
+              <Fi c="amber">30-day audit logs</Fi>
+              <Fi c="amber">Application activity log</Fi>
+              <Fi c="green">Up to 75 collaborators</Fi>
+            </ul>
+          </div>
+
+          {/* ENTERPRISE */}
+          <div style={card()}>
+            <TierName>Enterprise</TierName>
+            <div style={amt()}>Custom</div>
+            <div style={{ fontSize: 13, color: C.gray, marginTop: 4, marginBottom: 6 }}>&nbsp;</div>
+            <TierSeats>76+ seats · no RFP required · quote same day</TierSeats>
+            <p style={desc()}>
+              For large orgs and regulated sectors. SSO, extended audit retention, DPA, dedicated support, and custom
+              SLAs. Pay by invoice. POC / pilot available.
+            </p>
+            <Cta href="mailto:inbound@zephyr-cloud.io?subject=Enterprise" v="secondary">
+              Talk to sales
+            </Cta>
+            <ul style={featList()}>
+              <Fi c="green">
+                <strong style={{ color: C.white }}>Everything in Pro</strong>
+              </Fi>
+              <Divider />
+              {[
+                'SSO / SAML',
+                '60–90 day audit logs',
+                '99.9% uptime SLA',
+                'Data Processing Agreement',
+                'SOC 2 compliant',
+                'Dedicated support',
+                'Custom bandwidth / storage',
+                'Custom SLAs',
+              ].map((f) => (
+                <Fi key={f} c="amber">
+                  {f}
+                </Fi>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {/* ── ROI BANNER ── */}
+      <div style={{ maxWidth: 960, margin: '-56px auto 72px', padding: '0 24px', textAlign: 'center' }}>
+        <div
+          style={{
+            background: C.black3,
+            border: `1px solid ${C.border}`,
+            borderRadius: 10,
+            padding: '14px 24px',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 10,
+          }}
+        >
+          <span style={{ fontSize: 16, fontWeight: 900, color: C.purpleLight }}>1.5 sprints/quarter</span>
+          <span style={{ fontSize: 13, color: C.gray }}>
+            recovered by teams replacing internal MF tooling with Zephyr — based on customer data.
+          </span>
+        </div>
+      </div>
+
+      {/* ── PRO CALCULATOR ── */}
+      <div id="pro-calc" style={{ maxWidth: 960, margin: '0 auto 72px', padding: '0 24px' }}>
+        <div
+          style={{
+            background: 'linear-gradient(160deg,#1A0F3A 0%,#0F0F1A 60%)',
+            border: `1px solid ${C.purple}`,
+            borderRadius: 14,
+            padding: '40px 48px',
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+              marginBottom: 32,
+              gap: 24,
+              flexWrap: 'wrap',
+            }}
+          >
+            <div>
+              <h3 style={{ fontSize: 18, fontWeight: 900, letterSpacing: '-0.4px', color: C.white, marginBottom: 6 }}>
+                Pro — see your exact price
+              </h3>
+              <p style={{ fontSize: 13, color: C.gray, maxWidth: 400, lineHeight: 1.6 }}>
+                The more seats you add, the less you pay per seat. Click a tier or drag the slider.
+              </p>
+            </div>
+            <div style={{ textAlign: 'right', flexShrink: 0 }}>
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.8px',
+                  color: C.purpleLight,
+                  marginBottom: 4,
+                }}
+              >
+                {isAnnual ? 'Effective per month (annual)' : 'Total per month'}
               </div>
-              <div className="text-xs text-neutral-500 text-center pt-2">
-                Available on all paid plans • More providers coming soon
+              <div style={{ fontSize: 42, fontWeight: 900, letterSpacing: '-1.5px', color: C.white, lineHeight: 1 }}>
+                {fmt(moTotal)}
               </div>
+              <div style={{ fontSize: 12, color: C.gray, marginTop: 4 }}>
+                {isAnnual
+                  ? `Billed as ${fmt(yrTotal)}/yr · you save ${fmt(yrSave)}`
+                  : `${fmt(yrTotal)}/yr with annual billing — save ${fmt(yrSave)}`}
+              </div>
+            </div>
+          </div>
+
+          {/* Slider */}
+          <div style={{ marginBottom: 28 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+              <span style={{ fontSize: 12, color: C.grayDark, fontWeight: 500 }}>Seats</span>
+              <strong style={{ fontSize: 14, color: C.white, fontWeight: 800 }}>
+                {seats} seat{seats !== 1 ? 's' : ''}
+              </strong>
+            </div>
+            <input
+              type="range"
+              min={2}
+              max={75}
+              value={seats}
+              onChange={(e) => setSeats(parseInt(e.target.value))}
+              className="pricing-slider"
+              style={{
+                width: '100%',
+                height: 5,
+                borderRadius: 3,
+                outline: 'none',
+                WebkitAppearance: 'none',
+                cursor: 'pointer',
+                background: `linear-gradient(to right,${C.purple} 0%,${C.purple} ${sliderPct}%,${C.borderLight} ${sliderPct}%,${C.borderLight} 100%)`,
+              }}
+            />
+          </div>
+
+          {/* Band cards */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, marginBottom: 24 }}>
+            {PRO_BANDS.map((band, i) => {
+              const dr = isAnnual ? Math.round(band.rate * ANNUAL_DISC) : band.rate;
+              const saving = Math.round((1 - band.rate / INTRO_RATE) * 100);
+              const active = bandIdx === i;
+              return (
+                <div
+                  key={i}
+                  onClick={() => setSeats(band.midpoint)}
+                  style={{
+                    background: active ? 'rgba(139,92,246,0.15)' : 'rgba(255,255,255,0.04)',
+                    border: `1px solid ${active ? C.purple : 'rgba(255,255,255,0.06)'}`,
+                    boxShadow: active ? '0 0 16px rgba(139,92,246,0.1)' : 'none',
+                    borderRadius: 8,
+                    padding: '14px 12px',
+                    textAlign: 'center',
+                    transition: 'all 0.25s',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: 10,
+                      fontWeight: 700,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.5px',
+                      color: active ? C.purpleLight : C.grayDark,
+                      marginBottom: 6,
+                    }}
+                  >
+                    {band.label}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 22,
+                      fontWeight: 900,
+                      letterSpacing: '-0.8px',
+                      color: C.white,
+                      lineHeight: 1,
+                      marginBottom: 3,
+                    }}
+                  >
+                    {fmt(dr)}
+                  </div>
+                  <div style={{ fontSize: 10, color: C.grayDark }}>per seat / {isAnnual ? 'mo (annual)' : 'mo'}</div>
+                  <div style={{ fontSize: 10, fontWeight: 700, color: C.green, marginTop: 5, minHeight: 14 }}>
+                    {saving === 0 ? 'introductory rate' : `${saving}% less than intro`}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Meta */}
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              paddingTop: 20,
+              borderTop: '1px solid rgba(255,255,255,0.07)',
+              flexWrap: 'wrap',
+              gap: 12,
+            }}
+          >
+            <div style={{ fontSize: 12, color: C.gray }}>
+              Per seat:{' '}
+              <strong style={{ color: C.white }}>
+                {fmt(effRate)}
+                {isAnnual ? ` (was ${fmt(rate)})` : ''}
+              </strong>
+            </div>
+            <div style={{ fontSize: 12, color: C.gray }}>
+              Monthly: <strong style={{ color: C.white }}>{fmt(moTotal)}</strong>
+            </div>
+            <div style={{ fontSize: 12, color: C.gray }}>
+              Annual: <strong style={{ color: C.white }}>{fmt(yrTotal)}</strong>
+              <span
+                style={{
+                  display: 'inline-block',
+                  background: C.greenDim,
+                  color: C.green,
+                  fontSize: 11,
+                  fontWeight: 700,
+                  padding: '2px 8px',
+                  borderRadius: 6,
+                  marginLeft: 6,
+                }}
+              >
+                Save {fmt(yrSave)}
+              </span>
+            </div>
+            <div style={{ fontSize: 12, color: C.gray }}>
+              Need 76+ seats?{' '}
+              <a
+                href="mailto:inbound@zephyr-cloud.io?subject=Enterprise"
+                style={{ color: C.purpleLight, textDecoration: 'none', fontWeight: 700 }}
+              >
+                Talk to sales
+              </a>{' '}
+              — volume rates, quoted same day.
             </div>
           </div>
         </div>
       </div>
 
-      {/* Usage-Based Pricing */}
-      <div className="mb-16">
-        <h2 className="text-2xl font-bold mb-6 text-center">Simple, transparent overages</h2>
-        <div className="grid md:grid-cols-3 gap-6">
-          <Card className="bg-neutral-900">
-            <CardHeader>
-              <CardTitle className="text-lg">Personal</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="space-y-2 text-sm text-neutral-400">
-                <li>Bandwidth: $40 per 100GB</li>
-                <li>Storage: $10 per 50GB</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-neutral-900">
-            <CardHeader>
-              <CardTitle className="text-lg">Team</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="space-y-2 text-sm text-neutral-400">
-                <li>Bandwidth: $30 per 100GB</li>
-                <li>Storage: $7 per 50GB</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-neutral-900">
-            <CardHeader>
-              <CardTitle className="text-lg">Business</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="space-y-2 text-sm text-neutral-400">
-                <li>Bandwidth: $25 per 100GB</li>
-                <li>Storage: $5 per 50GB</li>
-              </ul>
-            </CardContent>
-          </Card>
-        </div>
+      {/* ── PROOF BAR ── */}
+      <div
+        style={{
+          borderTop: `1px solid ${C.border}`,
+          borderBottom: `1px solid ${C.border}`,
+          padding: '20px 40px',
+          display: 'flex',
+          justifyContent: 'center',
+          gap: 48,
+          flexWrap: 'wrap',
+          marginBottom: 80,
+        }}
+      >
+        {[
+          { n: '6', s: ',213', l: 'Monthly active users' },
+          { n: '15', s: '+', l: 'Bundler integrations' },
+          { n: '6', s: '+', l: 'Cloud integrations' },
+          { n: '15', s: '+', l: 'Countries' },
+          { n: 'SOC', s: ' 2', l: 'Compliant' },
+        ].map((s) => (
+          <div key={s.l} style={{ textAlign: 'center' }}>
+            <div style={{ fontSize: 22, fontWeight: 900, letterSpacing: '-0.8px', color: C.white, lineHeight: 1 }}>
+              {s.n}
+              <span style={{ color: C.purpleLight }}>{s.s}</span>
+            </div>
+            <div style={{ fontSize: 11, color: C.grayDark, marginTop: 3 }}>{s.l}</div>
+          </div>
+        ))}
       </div>
 
-      {/* FAQ Section */}
-      <div className="text-center">
-        <h2 className="text-2xl font-bold mb-4">Frequently asked questions</h2>
-        <p className="text-neutral-400 mb-6">Have questions? We're here to help.</p>
-        <div className="flex flex-wrap justify-center gap-4">
-          <Button variant="outline" asChild>
-            <a href="https://docs.zephyr-cloud.io/" target="_blank">
-              View Documentation
-            </a>
-          </Button>
-          <Button variant="outline" asChild>
-            <a href="mailto:support@zephyr-cloud.io">Contact Support</a>
-          </Button>
+      {/* ── SOCIAL PROOF ── */}
+      <section style={{ maxWidth: 960, margin: '0 auto 80px', padding: '0 24px' }}>
+        <div
+          style={{
+            background: C.black2,
+            border: `1px solid ${C.border}`,
+            borderRadius: 12,
+            padding: '32px 40px',
+            display: 'grid',
+            gridTemplateColumns: '1fr auto',
+            gap: 32,
+            alignItems: 'center',
+            marginBottom: 16,
+          }}
+        >
+          <div>
+            <p style={{ fontSize: 16, fontWeight: 600, color: C.white, lineHeight: 1.6, fontStyle: 'italic' }}>
+              <span style={{ color: C.purpleLight, fontSize: 24, lineHeight: 0, verticalAlign: -6, marginRight: 4 }}>
+                "
+              </span>
+              Zephyr gave us the deployment orchestration layer we'd been trying to build internally for two years. We
+              stopped writing tooling and started shipping product.
+              <span style={{ color: C.purpleLight, fontSize: 24, lineHeight: 0, verticalAlign: -6, marginLeft: 4 }}>
+                "
+              </span>
+            </p>
+            <p style={{ fontSize: 12, color: C.grayDark, marginTop: 10 }}>
+              Engineering leadership ·{' '}
+              <strong style={{ color: C.gray, fontWeight: 600 }}>Southern Glazer's Wine &amp; Spirits</strong>
+            </p>
+          </div>
+          <div
+            style={{
+              textAlign: 'right',
+              fontSize: 11,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '1px',
+              color: C.grayDark,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            <span
+              style={{
+                display: 'block',
+                fontSize: 18,
+                fontWeight: 900,
+                color: C.white,
+                letterSpacing: '-0.5px',
+                marginBottom: 4,
+              }}
+            >
+              Southern
+              <br />
+              Glazer's
+            </span>
+            Enterprise customer
+          </div>
         </div>
-      </div>
+        <div
+          style={{
+            background: C.black2,
+            border: `1px solid ${C.border}`,
+            borderRadius: 12,
+            padding: '28px 40px',
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+          }}
+        >
+          <div style={{ paddingRight: 32, borderRight: `1px solid ${C.border}` }}>
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.8px',
+                color: C.purpleLight,
+                marginBottom: 8,
+              }}
+            >
+              Teams using Zephyr report
+            </div>
+            <div style={{ fontSize: 32, fontWeight: 900, letterSpacing: '-1px', color: C.white, lineHeight: 1 }}>
+              1.5 sprints
+            </div>
+            <div style={{ fontSize: 13, color: C.gray, marginTop: 4 }}>
+              recovered per quarter by eliminating internal MF tooling
+            </div>
+          </div>
+          <div style={{ paddingLeft: 32 }}>
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.8px',
+                color: C.purpleLight,
+                marginBottom: 8,
+              }}
+            >
+              Average time to first deploy
+            </div>
+            <div style={{ fontSize: 32, fontWeight: 900, letterSpacing: '-1px', color: C.white, lineHeight: 1 }}>
+              &lt; 15 min
+            </div>
+            <div style={{ fontSize: 13, color: C.gray, marginTop: 4 }}>
+              from signup to first cloud deployment — no infrastructure migration required
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── FEATURE TABLE ── */}
+      <section style={{ maxWidth: 960, margin: '0 auto 80px', padding: '0 24px' }}>
+        <div style={{ textAlign: 'center', marginBottom: 36 }}>
+          <h2 style={{ fontSize: 28, fontWeight: 900, letterSpacing: '-0.6px', marginBottom: 8 }}>
+            Everything in the platform
+          </h2>
+          <p style={{ fontSize: 14, color: C.gray }}>Every feature, every tier.</p>
+        </div>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <thead>
+            <tr>
+              {[
+                ['Feature', 'left', C.grayDark, '40%'],
+                ['Free', 'center', C.grayDark],
+                ['Pro', 'center', C.purpleLight],
+                ['Enterprise', 'center', C.grayDark],
+              ].map(([label, align, color, w]) => (
+                <th
+                  key={label as string}
+                  style={{
+                    padding: '10px 16px',
+                    fontSize: 10,
+                    fontWeight: 700,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.8px',
+                    color: color as string,
+                    textAlign: align as 'left' | 'center',
+                    borderBottom: `1px solid ${C.border}`,
+                    width: w as string | undefined,
+                  }}
+                >
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {(
+              [
+                { g: 'Deployment' },
+                { f: 'Cloud integrations', fr: '1', pr: 'All', en: 'All' },
+                { f: 'Bundler plugins (15)', fr: '✓', pr: '✓', en: '✓' },
+                { f: 'BYOC', fr: '—', pr: '✓', en: '✓' },
+                { f: 'Instant rollbacks', fr: '—', pr: '✓', en: '✓' },
+                { f: 'Tag / branch env', fr: '✓', pr: '✓', en: '✓' },
+                { f: 'Version history', fr: 'Limited', pr: '✓', en: 'Custom' },
+                { g: 'Module Federation Native', mfg: true },
+                { f: 'Environment Overrides', fr: '—', pr: '✓', en: '✓', mf: true },
+                { f: 'Env Variables (no redeploy)', fr: '—', pr: '✓', en: '✓' },
+                { f: 'Zephyr DevTools', fr: '—', pr: '✓', en: '✓', mf: true },
+                { f: 'UML architecture map', fr: '—', pr: '✓', en: '✓', mf: true },
+                { f: 'zephyr.dependencies', fr: '—', pr: '✓', en: '✓', mf: true },
+                { g: 'Teams & Access' },
+                { f: 'Collaborators', fr: '—', pr: 'Up to 75', en: 'Unlimited' },
+                { f: 'Per-team permissions', fr: '—', pr: '✓', en: '✓' },
+                { f: 'SSO / SAML', fr: '—', pr: '—', en: '✓' },
+                { g: 'Security & Compliance' },
+                { f: 'Activity log', fr: '—', pr: '✓', en: '✓' },
+                { f: 'Audit log retention', fr: '—', pr: '30 days', en: '60–90 days' },
+                { f: 'SOC 2 compliance', fr: '—', pr: '—', en: '✓' },
+                { f: 'DPA', fr: '—', pr: '—', en: '✓' },
+                { f: 'Uptime SLA', fr: '—', pr: '—', en: '99.9%' },
+              ] as Array<{ g?: string; mfg?: boolean; f?: string; fr?: string; pr?: string; en?: string; mf?: boolean }>
+            ).map((row, i) => {
+              if (row.g)
+                return (
+                  <tr key={i}>
+                    <td
+                      colSpan={4}
+                      style={{
+                        background: C.black3,
+                        color: C.grayDark,
+                        fontSize: 10,
+                        fontWeight: 700,
+                        textTransform: 'uppercase',
+                        letterSpacing: '1px',
+                        padding: '8px 16px',
+                        borderTop: `1px solid ${C.border}`,
+                      }}
+                    >
+                      {row.g}
+                      {row.mfg && (
+                        <span style={{ marginLeft: 6 }}>
+                          <MfTag />
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              const cell = (val = '', isP = false) => {
+                const color =
+                  val === '✓'
+                    ? C.green
+                    : val === '—'
+                      ? C.borderLight
+                      : val === 'Limited'
+                        ? C.grayDark
+                        : val === 'Custom' || val === 'Unlimited'
+                          ? C.purpleLight
+                          : C.gray;
+                return (
+                  <td
+                    style={{
+                      padding: '11px 16px',
+                      borderBottom: `1px solid ${C.border}`,
+                      textAlign: 'center',
+                      color,
+                      background: isP ? 'rgba(139,92,246,0.04)' : 'transparent',
+                      fontSize: val === '✓' || val === '—' ? 14 : 11,
+                      fontWeight: val === 'Limited' || val === 'Custom' ? 700 : 400,
+                    }}
+                  >
+                    {val}
+                  </td>
+                );
+              };
+              return (
+                <tr key={i} className={cn(path === 'nonmf' && row.mf && 'opacity-40')}>
+                  <td
+                    style={{
+                      padding: '11px 16px',
+                      borderBottom: `1px solid ${C.border}`,
+                      color: C.white,
+                      fontWeight: 500,
+                    }}
+                  >
+                    {row.f}
+                    {row.mf && (
+                      <span style={{ marginLeft: 6 }}>
+                        <MfTag />
+                      </span>
+                    )}
+                  </td>
+                  {cell(row.fr)}
+                  {cell(row.pr, true)}
+                  {cell(row.en)}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </section>
+
+      {/* ── FAQ ── */}
+      <section style={{ maxWidth: 680, margin: '0 auto 80px', padding: '0 24px' }}>
+        <div style={{ textAlign: 'center', marginBottom: 36 }}>
+          <h2 style={{ fontSize: 28, fontWeight: 900, letterSpacing: '-0.6px' }}>Common questions</h2>
+        </div>
+        {faqs.map((faq, i) => (
+          <div key={i} style={{ borderBottom: `1px solid ${C.border}` }}>
+            <button
+              onClick={() => setOpenFaq(openFaq === i ? null : i)}
+              style={{
+                width: '100%',
+                background: 'none',
+                border: 'none',
+                color: C.white,
+                fontFamily: 'inherit',
+                fontSize: 14,
+                fontWeight: 600,
+                textAlign: 'left',
+                padding: '18px 0',
+                cursor: 'pointer',
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                gap: 16,
+              }}
+            >
+              {faq.q}
+              <span
+                style={{
+                  color: openFaq === i ? C.purpleLight : C.grayDark,
+                  fontSize: 18,
+                  flexShrink: 0,
+                  transition: 'transform 0.2s',
+                  display: 'inline-block',
+                  transform: openFaq === i ? 'rotate(45deg)' : 'none',
+                }}
+              >
+                +
+              </span>
+            </button>
+            {openFaq === i && (
+              <div style={{ fontSize: 13, color: C.gray, lineHeight: 1.75, paddingBottom: 18 }}>{faq.a}</div>
+            )}
+          </div>
+        ))}
+      </section>
+
+      {/* ── FINAL CTA ── */}
+      <section style={{ textAlign: 'center', padding: '80px 40px 100px', borderTop: `1px solid ${C.border}` }}>
+        <h2 style={{ fontSize: 40, fontWeight: 900, letterSpacing: '-1px', lineHeight: 1.1, marginBottom: 14 }}>
+          Start free.
+          <br />
+          <span style={{ color: C.purpleLight }}>No cliff. No lock-in.</span>
+        </h2>
+        <p style={{ fontSize: 16, color: C.gray, marginBottom: 32 }}>
+          One cloud integration free, forever. Upgrade when your team is ready.
+        </p>
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap', marginBottom: 24 }}>
+          <a
+            href="https://app.zephyr-cloud.io/"
+            target="_blank"
+            style={{
+              background: C.purple,
+              color: 'white',
+              fontSize: 14,
+              fontWeight: 700,
+              padding: '14px 32px',
+              borderRadius: 8,
+              textDecoration: 'none',
+            }}
+          >
+            Start for free
+          </a>
+          <a
+            href="mailto:inbound@zephyr-cloud.io?subject=Sales"
+            target="_blank"
+            style={{
+              background: 'transparent',
+              border: `1px solid ${C.borderLight}`,
+              color: C.white,
+              fontSize: 14,
+              fontWeight: 600,
+              padding: '14px 32px',
+              borderRadius: 8,
+              textDecoration: 'none',
+            }}
+          >
+            Talk to sales
+          </a>
+        </div>
+        <div style={{ display: 'flex', gap: 20, justifyContent: 'center', flexWrap: 'wrap' }}>
+          {[
+            'No credit card required',
+            'Cancel anytime',
+            'BYOC — your data stays in your cloud',
+            'Invoice billing available',
+            'Export your data anytime',
+          ].map((t) => (
+            <span key={t} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: C.grayDark }}>
+              <span
+                style={{
+                  width: 5,
+                  height: 5,
+                  borderRadius: '50%',
+                  background: C.green,
+                  flexShrink: 0,
+                  display: 'inline-block',
+                }}
+              />
+              {t}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      {/* Slider thumb styles */}
+      <style>{`
+        .pricing-slider::-webkit-slider-thumb { -webkit-appearance:none; width:22px; height:22px; border-radius:50%; background:${C.purple}; cursor:pointer; box-shadow:0 0 0 4px rgba(139,92,246,0.2); border:2px solid ${C.white}; }
+        .pricing-slider::-moz-range-thumb { width:22px; height:22px; border-radius:50%; background:${C.purple}; cursor:pointer; border:2px solid ${C.white}; }
+      `}</style>
     </div>
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const card = () => ({
+  background: C.black2,
+  border: `1px solid ${C.border}`,
+  borderRadius: 14,
+  padding: '32px 28px',
+  position: 'relative' as const,
+});
+const amt = () => ({ fontSize: 48, fontWeight: 900, letterSpacing: '-2px', color: C.white, lineHeight: 1 });
+const desc = () => ({ fontSize: 13, color: C.gray, lineHeight: 1.65, marginBottom: 24 });
+const featList = () => ({
+  listStyle: 'none' as const,
+  display: 'flex' as const,
+  flexDirection: 'column' as const,
+  gap: 10,
+});
+
+function TierName({ children, purple }: { children: React.ReactNode; purple?: boolean }) {
+  return (
+    <div
+      style={{
+        fontSize: 12,
+        fontWeight: 700,
+        textTransform: 'uppercase',
+        letterSpacing: '1px',
+        color: purple ? C.purpleLight : C.grayDark,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+function TierSeats({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        fontSize: 12,
+        color: C.grayDark,
+        paddingBottom: 18,
+        marginBottom: 18,
+        borderBottom: `1px solid ${C.border}`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+function Cta({ href, children, v }: { href: string; children: React.ReactNode; v: 'primary' | 'secondary' }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      style={{
+        display: 'block',
+        width: '100%',
+        textAlign: 'center',
+        padding: '12px 20px',
+        borderRadius: 8,
+        fontSize: 14,
+        fontWeight: 700,
+        textDecoration: 'none',
+        marginBottom: 24,
+        transition: 'all 0.2s',
+        ...(v === 'primary'
+          ? { background: C.purple, color: 'white' }
+          : { background: 'transparent', border: `1px solid ${C.borderLight}`, color: C.white }),
+      }}
+    >
+      {children}
+    </a>
+  );
+}
+function Fi({ children, c, dim }: { children: React.ReactNode; c: 'green' | 'purple' | 'amber'; dim?: boolean }) {
+  const ic = c === 'green' ? C.green : c === 'purple' ? C.purpleLight : C.amber;
+  return (
+    <li
+      style={{
+        fontSize: 13,
+        color: C.gray,
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 9,
+        lineHeight: 1.45,
+        opacity: dim ? 0.4 : 1,
+      }}
+    >
+      <span style={{ color: ic, fontSize: 12, marginTop: 1, flexShrink: 0 }}>✓</span>
+      {children}
+    </li>
+  );
+}
+function Divider() {
+  return (
+    <li>
+      <hr style={{ border: 'none', borderTop: `1px dashed ${C.border}`, margin: '6px 0' }} />
+    </li>
+  );
+}
+function MfTag() {
+  return (
+    <span
+      style={{
+        background: C.purpleDim,
+        color: C.purpleLight,
+        fontSize: 9,
+        fontWeight: 700,
+        textTransform: 'uppercase',
+        letterSpacing: '0.5px',
+        padding: '1px 5px',
+        borderRadius: 3,
+        marginLeft: 4,
+        verticalAlign: 'middle',
+      }}
+    >
+      MF
+    </span>
   );
 }

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -68,6 +68,7 @@ function PricingPage() {
   const [openFaq, setOpenFaq] = useState<number | null>(null);
   const billingRef = useRef<HTMLDivElement>(null);
   const tiersRef = useRef<HTMLElement>(null);
+  const panelsRef = useRef<HTMLDivElement>(null);
   const isAnnual = billing === 'annual';
 
   useEffect(() => {
@@ -78,7 +79,7 @@ function PricingPage() {
 
   function selectPath(p: 'mf' | 'nonmf') {
     setPath(p);
-    setTimeout(() => tiersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 300);
+    setTimeout(() => panelsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
   }
 
   // Pro calc
@@ -268,147 +269,151 @@ function PricingPage() {
       </section>
 
       {/* ── VALUE PANELS ── */}
-      {(['mf', 'nonmf'] as const).map((panelId) => {
-        const isMf = panelId === 'mf';
-        const visible = path === panelId;
-        const accent = isMf ? C.purpleLight : C.green;
-        const pains = isMf
-          ? [
-              {
-                problem:
-                  "CI is a bottleneck for critical deploys. You're waiting on pipelines to push a config change.",
-                solution: 'Environment Overrides',
-                mf: true,
-              },
-              {
-                problem:
-                  'Engineers maintain internal tooling to develop locally against MFEs. It eats sprint capacity every cycle.',
-                solution: 'Zephyr DevTools',
-                mf: true,
-              },
-              {
-                problem:
-                  'No visibility into who deployed what across remotes. Audit and compliance reviews are painful.',
-                solution: 'Audit logs + Activity',
-                mf: false,
-              },
-            ]
-          : [
-              {
-                problem: "You're locked to Vercel or Netlify. Migrating or going multi-cloud is a project in itself.",
-                solution: 'BYOC — bring your own cloud',
-                mf: false,
-              },
-              {
-                problem:
-                  "Rollbacks mean redeploying. When something breaks in production, you're waiting on the pipeline.",
-                solution: 'Instant rollbacks, any cloud',
-                mf: false,
-              },
-              {
-                problem:
-                  'Changing an environment variable triggers a full redeploy. Small config changes block shipping.',
-                solution: 'Env Variables, no redeploy',
-                mf: false,
-              },
-            ];
-        return (
-          <div
-            key={panelId}
-            style={{
-              maxWidth: 960,
-              padding: '0 24px',
-              overflow: 'hidden',
-              maxHeight: visible ? 600 : 0,
-              opacity: visible ? 1 : 0,
-              marginLeft: 'auto',
-              marginRight: 'auto',
-              marginTop: visible ? 48 : 0,
-              marginBottom: visible ? 56 : 0,
-              transition: 'max-height 0.5s ease, opacity 0.4s ease, margin 0.4s ease',
-            }}
-          >
+      <div ref={panelsRef}>
+        {(['mf', 'nonmf'] as const).map((panelId) => {
+          const isMf = panelId === 'mf';
+          const visible = path === panelId;
+          const accent = isMf ? C.purpleLight : C.green;
+          const pains = isMf
+            ? [
+                {
+                  problem:
+                    "CI is a bottleneck for critical deploys. You're waiting on pipelines to push a config change.",
+                  solution: 'Environment Overrides',
+                  mf: true,
+                },
+                {
+                  problem:
+                    'Engineers maintain internal tooling to develop locally against MFEs. It eats sprint capacity every cycle.',
+                  solution: 'Zephyr DevTools',
+                  mf: true,
+                },
+                {
+                  problem:
+                    'No visibility into who deployed what across remotes. Audit and compliance reviews are painful.',
+                  solution: 'Audit logs + Activity',
+                  mf: false,
+                },
+              ]
+            : [
+                {
+                  problem: "You're locked to Vercel or Netlify. Migrating or going multi-cloud is a project in itself.",
+                  solution: 'BYOC — bring your own cloud',
+                  mf: false,
+                },
+                {
+                  problem:
+                    "Rollbacks mean redeploying. When something breaks in production, you're waiting on the pipeline.",
+                  solution: 'Instant rollbacks, any cloud',
+                  mf: false,
+                },
+                {
+                  problem:
+                    'Changing an environment variable triggers a full redeploy. Small config changes block shipping.',
+                  solution: 'Env Variables, no redeploy',
+                  mf: false,
+                },
+              ];
+          return (
             <div
+              key={panelId}
               style={{
-                borderRadius: 14,
-                padding: '40px 48px',
-                background: isMf
-                  ? 'linear-gradient(135deg,#1A0F3A 0%,#0F0F1A 70%)'
-                  : 'linear-gradient(135deg,#062A1F 0%,#0F0F1A 70%)',
-                border: `1px solid ${isMf ? 'rgba(139,92,246,0.3)' : 'rgba(16,185,129,0.25)'}`,
+                maxWidth: 960,
+                padding: '0 24px',
+                overflow: 'hidden',
+                maxHeight: visible ? 600 : 0,
+                opacity: visible ? 1 : 0,
+                marginLeft: 'auto',
+                marginRight: 'auto',
+                marginTop: visible ? 48 : 0,
+                marginBottom: visible ? 56 : 0,
+                transition: 'max-height 0.5s ease, opacity 0.4s ease, margin 0.4s ease',
               }}
             >
-              <div style={{ marginBottom: 32 }}>
-                <div
-                  style={{
-                    fontSize: 10,
-                    fontWeight: 700,
-                    textTransform: 'uppercase',
-                    letterSpacing: '1.2px',
-                    color: accent,
-                    marginBottom: 10,
-                  }}
-                >
-                  {isMf ? 'For Module Federation teams' : 'For teams not yet on Module Federation'}
-                </div>
-                <h2 style={{ fontSize: 26, fontWeight: 900, letterSpacing: '-0.6px', lineHeight: 1.2, color: C.white }}>
-                  {isMf ? (
-                    <>
-                      You adopted MF. Now you need the platform{' '}
-                      <em style={{ fontStyle: 'normal', color: accent }}>built around it.</em>
-                    </>
-                  ) : (
-                    <>
-                      Your deployment stack shouldn't be{' '}
-                      <em style={{ fontStyle: 'normal', color: accent }}>owned by your cloud provider.</em>
-                    </>
-                  )}
-                </h2>
-              </div>
-              <div className="value-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
-                {pains.map((item, i) => (
+              <div
+                style={{
+                  borderRadius: 14,
+                  padding: '40px 48px',
+                  background: isMf
+                    ? 'linear-gradient(135deg,#1A0F3A 0%,#0F0F1A 70%)'
+                    : 'linear-gradient(135deg,#062A1F 0%,#0F0F1A 70%)',
+                  border: `1px solid ${isMf ? 'rgba(139,92,246,0.3)' : 'rgba(16,185,129,0.25)'}`,
+                }}
+              >
+                <div style={{ marginBottom: 32 }}>
                   <div
-                    key={i}
                     style={{
-                      background: 'rgba(255,255,255,0.04)',
-                      borderRadius: 10,
-                      padding: '18px 16px',
-                      border: '1px solid rgba(255,255,255,0.06)',
+                      fontSize: 10,
+                      fontWeight: 700,
+                      textTransform: 'uppercase',
+                      letterSpacing: '1.2px',
+                      color: accent,
+                      marginBottom: 10,
                     }}
                   >
-                    <div
-                      style={{
-                        fontSize: 11,
-                        color: C.grayDark,
-                        marginBottom: 6,
-                        fontWeight: 600,
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.5px',
-                      }}
-                    >
-                      The problem
-                    </div>
-                    <p style={{ fontSize: 13, color: C.gray, lineHeight: 1.5, marginBottom: 10 }}>{item.problem}</p>
-                    <div
-                      style={{
-                        fontSize: 12,
-                        fontWeight: 700,
-                        color: accent,
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 6,
-                      }}
-                    >
-                      → {item.solution}
-                      {item.mf && <MfTag />}
-                    </div>
+                    {isMf ? 'For Module Federation teams' : 'For teams not yet on Module Federation'}
                   </div>
-                ))}
+                  <h2
+                    style={{ fontSize: 26, fontWeight: 900, letterSpacing: '-0.6px', lineHeight: 1.2, color: C.white }}
+                  >
+                    {isMf ? (
+                      <>
+                        You adopted MF. Now you need the platform{' '}
+                        <em style={{ fontStyle: 'normal', color: accent }}>built around it.</em>
+                      </>
+                    ) : (
+                      <>
+                        Your deployment stack shouldn't be{' '}
+                        <em style={{ fontStyle: 'normal', color: accent }}>owned by your cloud provider.</em>
+                      </>
+                    )}
+                  </h2>
+                </div>
+                <div className="value-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
+                  {pains.map((item, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        background: 'rgba(255,255,255,0.04)',
+                        borderRadius: 10,
+                        padding: '18px 16px',
+                        border: '1px solid rgba(255,255,255,0.06)',
+                      }}
+                    >
+                      <div
+                        style={{
+                          fontSize: 11,
+                          color: C.grayDark,
+                          marginBottom: 6,
+                          fontWeight: 600,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.5px',
+                        }}
+                      >
+                        The problem
+                      </div>
+                      <p style={{ fontSize: 13, color: C.gray, lineHeight: 1.5, marginBottom: 10 }}>{item.problem}</p>
+                      <div
+                        style={{
+                          fontSize: 12,
+                          fontWeight: 700,
+                          color: accent,
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 6,
+                        }}
+                      >
+                        → {item.solution}
+                        {item.mf && <MfTag />}
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
 
       {/* ── BILLING TOGGLE ── */}
       <div ref={billingRef} style={{ textAlign: 'center', padding: '0 24px 24px' }}>

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -184,16 +184,16 @@ function PricingPage() {
           style={{
             display: 'flex',
             alignItems: 'center',
-            justifyContent: 'center',
-            flexWrap: 'wrap',
-            gap: 28,
-            marginBottom: 20,
+            justifyContent: 'space-between',
+            flexWrap: 'nowrap',
+            gap: 0,
             background: 'linear-gradient(135deg, #1A0F3A 0%, #0F0F1A 100%)',
             border: `1px solid rgba(139,92,246,0.25)`,
             borderRadius: 12,
             padding: '14px 32px',
-            maxWidth: 760,
+            maxWidth: 860,
             margin: '0 auto 20px',
+            overflowX: 'auto',
           }}
         >
           {(

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -415,19 +415,36 @@ function PricingPage() {
           style={{
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 4,
+            position: 'relative',
             background: 'var(--card)',
             border: '1px solid var(--border)',
             borderRadius: 40,
             padding: 4,
           }}
         >
+          {/* sliding pill */}
+          <div
+            style={{
+              position: 'absolute',
+              top: 4,
+              bottom: 4,
+              left: 4,
+              width: 'calc(50% - 4px)',
+              background: 'var(--primary)',
+              borderRadius: 9999,
+              transform: isAnnual ? 'translateX(100%)' : 'translateX(0)',
+              transition: 'transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
+              pointerEvents: 'none',
+            }}
+          />
           {(['monthly', 'annual'] as const).map((mode) => (
             <button
               key={mode}
               onClick={() => setBilling(mode)}
               style={{
-                background: billing === mode ? 'var(--primary)' : 'none',
+                position: 'relative',
+                zIndex: 1,
+                background: 'none',
                 border: 'none',
                 color: billing === mode ? 'var(--primary-foreground)' : 'var(--muted-foreground)',
                 fontSize: 13,
@@ -435,11 +452,9 @@ function PricingPage() {
                 padding: '8px 16px',
                 borderRadius: 9999,
                 cursor: 'pointer',
-                transition: 'all 0.2s',
+                transition: 'color 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
                 fontFamily: 'inherit',
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
+                minWidth: 80,
               }}
             >
               {mode === 'monthly' ? 'Monthly' : 'Yearly'}
@@ -1031,7 +1046,6 @@ function PricingPage() {
                 const seats = calcTab === 'pro' ? proSeats : bizSeats;
                 const annualCost = calcTab === 'pro' ? proYearly : bizYearly;
                 const acColor = calcTab === 'pro' ? 'var(--primary)' : 'var(--muted-foreground)';
-                const acRgb = calcTab === 'pro' ? 'var(--primary)' : 'var(--muted-foreground)';
                 const deploysPerSeatPerYear = 250;
                 const minsSavedPerDeploy = 12;
                 const hourlyRate = 75;
@@ -1128,146 +1142,154 @@ function PricingPage() {
 
       {/* ── PROOF BAR ── (hidden) */}
 
-      {/* ── SOCIAL PROOF ── */}
-      <section style={{ maxWidth: 960, margin: '0 auto 80px', padding: '0 24px' }}>
-        <div
-          className="testimonial-card"
-          style={{
-            background: '#0d0d0d',
-            border: '1px solid var(--border)',
-            borderRadius: 16,
-            padding: '32px 40px',
-            marginBottom: 16,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 32,
-          }}
-        >
-          <div style={{ flex: 1 }}>
-            <span
-              style={{
-                display: 'block',
-                fontSize: 11,
-                fontWeight: 600,
-                textTransform: 'uppercase',
-                letterSpacing: '1px',
-                color: 'var(--muted-foreground)',
-                marginBottom: 16,
-              }}
-            >
-              Enterprise customer
-            </span>
-            <p
-              style={{
-                fontSize: 16,
-                fontWeight: 600,
-                color: 'var(--foreground)',
-                lineHeight: 1.6,
-                fontStyle: 'italic',
-              }}
-            >
+      {/* ── SOCIAL PROOF ── (hidden) */}
+      {false && (
+        <section style={{ maxWidth: 960, margin: '0 auto 80px', padding: '0 24px' }}>
+          <div
+            className="testimonial-card"
+            style={{
+              background: '#0d0d0d',
+              border: '1px solid var(--border)',
+              borderRadius: 16,
+              padding: '32px 40px',
+              marginBottom: 16,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 32,
+            }}
+          >
+            <div style={{ flex: 1 }}>
               <span
                 style={{
-                  color: 'var(--primary-muted)',
-                  fontSize: 24,
-                  lineHeight: 0,
-                  verticalAlign: -6,
-                  marginRight: 4,
+                  display: 'block',
+                  fontSize: 11,
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '1px',
+                  color: 'var(--muted-foreground)',
+                  marginBottom: 16,
                 }}
               >
-                "
+                Enterprise customer
               </span>
-              Zephyr gave us the deployment orchestration layer we'd been trying to build internally for two years. We
-              stopped writing tooling and started shipping product.
-              <span
-                style={{ color: 'var(--primary-muted)', fontSize: 24, lineHeight: 0, verticalAlign: -6, marginLeft: 4 }}
+              <p
+                style={{
+                  fontSize: 16,
+                  fontWeight: 600,
+                  color: 'var(--foreground)',
+                  lineHeight: 1.6,
+                  fontStyle: 'italic',
+                }}
               >
-                "
-              </span>
-            </p>
-            <p style={{ fontSize: 12, color: 'var(--muted-foreground)', marginTop: 8 }}>
-              Engineering leadership ·{' '}
-              <strong style={{ color: 'var(--foreground)', fontWeight: 600 }}>
-                Southern Glazer's Wine &amp; Spirits
-              </strong>
-            </p>
+                <span
+                  style={{
+                    color: 'var(--primary-muted)',
+                    fontSize: 24,
+                    lineHeight: 0,
+                    verticalAlign: -6,
+                    marginRight: 4,
+                  }}
+                >
+                  "
+                </span>
+                Zephyr gave us the deployment orchestration layer we'd been trying to build internally for two years. We
+                stopped writing tooling and started shipping product.
+                <span
+                  style={{
+                    color: 'var(--primary-muted)',
+                    fontSize: 24,
+                    lineHeight: 0,
+                    verticalAlign: -6,
+                    marginLeft: 4,
+                  }}
+                >
+                  "
+                </span>
+              </p>
+              <p style={{ fontSize: 12, color: 'var(--muted-foreground)', marginTop: 8 }}>
+                Engineering leadership ·{' '}
+                <strong style={{ color: 'var(--foreground)', fontWeight: 600 }}>
+                  Southern Glazer's Wine &amp; Spirits
+                </strong>
+              </p>
+            </div>
+            <img
+              className="testimonial-logo"
+              src={sgwsLogo}
+              alt="Southern Glazer's Wine & Spirits"
+              style={{ height: 72, width: 72, objectFit: 'contain', opacity: 0.9, flexShrink: 0 }}
+            />
           </div>
-          <img
-            className="testimonial-logo"
-            src={sgwsLogo}
-            alt="Southern Glazer's Wine & Spirits"
-            style={{ height: 72, width: 72, objectFit: 'contain', opacity: 0.9, flexShrink: 0 }}
-          />
-        </div>
-        <div
-          className="stats-grid"
-          style={{
-            background: 'var(--card)',
-            border: '1px solid var(--border)',
-            borderRadius: 16,
-            padding: '32px 40px',
-            display: 'grid',
-            gridTemplateColumns: '1fr 1fr',
-          }}
-        >
-          <div style={{ paddingRight: 32, borderRight: '1px solid var(--border)' }}>
-            <div
-              style={{
-                fontSize: 11,
-                fontWeight: 600,
-                textTransform: 'uppercase',
-                letterSpacing: '0.8px',
-                color: 'var(--muted-foreground)',
-                marginBottom: 8,
-              }}
-            >
-              Teams using Zephyr report
+          <div
+            className="stats-grid"
+            style={{
+              background: 'var(--card)',
+              border: '1px solid var(--border)',
+              borderRadius: 16,
+              padding: '32px 40px',
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+            }}
+          >
+            <div style={{ paddingRight: 32, borderRight: '1px solid var(--border)' }}>
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.8px',
+                  color: 'var(--muted-foreground)',
+                  marginBottom: 8,
+                }}
+              >
+                Teams using Zephyr report
+              </div>
+              <div
+                style={{
+                  fontSize: 32,
+                  fontWeight: 600,
+                  letterSpacing: '-1px',
+                  color: 'var(--foreground)',
+                  lineHeight: 1,
+                }}
+              >
+                1.5 sprints
+              </div>
+              <div style={{ fontSize: 13, color: 'var(--muted-foreground)', marginTop: 4 }}>
+                recovered per quarter by eliminating internal MF tooling
+              </div>
             </div>
-            <div
-              style={{
-                fontSize: 32,
-                fontWeight: 600,
-                letterSpacing: '-1px',
-                color: 'var(--foreground)',
-                lineHeight: 1,
-              }}
-            >
-              1.5 sprints
-            </div>
-            <div style={{ fontSize: 13, color: 'var(--muted-foreground)', marginTop: 4 }}>
-              recovered per quarter by eliminating internal MF tooling
-            </div>
-          </div>
-          <div style={{ paddingLeft: 32 }}>
-            <div
-              style={{
-                fontSize: 11,
-                fontWeight: 600,
-                textTransform: 'uppercase',
-                letterSpacing: '0.8px',
-                color: 'var(--muted-foreground)',
-                marginBottom: 8,
-              }}
-            >
-              Average time to first deploy
-            </div>
-            <div
-              style={{
-                fontSize: 32,
-                fontWeight: 600,
-                letterSpacing: '-1px',
-                color: 'var(--foreground)',
-                lineHeight: 1,
-              }}
-            >
-              &lt; 15 min
-            </div>
-            <div style={{ fontSize: 13, color: 'var(--muted-foreground)', marginTop: 4 }}>
-              from signup to first cloud deployment — no infrastructure migration required
+            <div style={{ paddingLeft: 32 }}>
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.8px',
+                  color: 'var(--muted-foreground)',
+                  marginBottom: 8,
+                }}
+              >
+                Average time to first deploy
+              </div>
+              <div
+                style={{
+                  fontSize: 32,
+                  fontWeight: 600,
+                  letterSpacing: '-1px',
+                  color: 'var(--foreground)',
+                  lineHeight: 1,
+                }}
+              >
+                &lt; 15 min
+              </div>
+              <div style={{ fontSize: 13, color: 'var(--muted-foreground)', marginTop: 4 }}>
+                from signup to first cloud deployment — no infrastructure migration required
+              </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
 
       {/* ── FEATURE TABLE ── */}
       <section style={{ maxWidth: 1280, margin: '0 auto 80px', padding: '0 24px' }}>

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1,7 +1,7 @@
 import sgwsLogo from '@/images/companies/sgws.webp';
 import { cn } from '@/lib/utils';
 import { createFileRoute } from '@tanstack/react-router';
-import { Check, ChevronDown } from 'lucide-react';
+import { Check, ChevronDown, X as XIcon } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 
 export const Route = createFileRoute('/pricing')({
@@ -1148,7 +1148,7 @@ function PricingPage() {
           <div
             className="testimonial-card"
             style={{
-              background: '#0d0d0d',
+              background: 'transparent',
               border: '1px solid var(--border)',
               borderRadius: 16,
               padding: '32px 40px',
@@ -1339,7 +1339,7 @@ function PricingPage() {
             overflowX: 'auto',
             borderRadius: 16,
             border: '1px solid rgba(255,255,255,0.1)',
-            background: '#0d0d0d',
+            background: 'transparent',
             boxShadow: '0 20px 60px rgba(0,0,0,0.28)',
           }}
         >
@@ -1379,33 +1379,33 @@ function PricingPage() {
                   { f: 'Cloud integrations', fr: '1', pr: 'All', bz: 'All', en: 'All' },
                   { f: 'Bundler plugins (15)', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'BYOC', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
-                  { f: 'Instant rollbacks', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Instant rollbacks', fr: '✕', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Tag / branch env', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Version history', fr: 'Limited', pr: '✓', bz: '✓', en: 'Custom' },
                   { g: 'Module Federation Native', sub: 'Built for MF teams, not bolted on', mfg: true },
-                  { f: 'Environment Overrides', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
-                  { f: 'Env Variables (no redeploy)', fr: '—', pr: '✓', bz: '✓', en: '✓' },
-                  { f: 'Zephyr DevTools', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
-                  { f: 'UML architecture map', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
-                  { f: 'zephyr.dependencies', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'Environment Overrides', fr: '✕', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'Env Variables (no redeploy)', fr: '✕', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Zephyr DevTools', fr: '✕', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'UML architecture map', fr: '✕', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'zephyr.dependencies', fr: '✕', pr: '✓', bz: '✓', en: '✓', mf: true },
                   { g: 'Teams & Access', sub: 'Roles, seat management, and permissions' },
-                  { f: 'Collaborators', fr: '—', pr: 'Up to 75', bz: 'Up to 200', en: 'Unlimited' },
-                  { f: 'Per-team permissions', fr: '—', pr: '✓', bz: '✓', en: '✓' },
-                  { f: 'Advanced roles', fr: '—', pr: '—', bz: '✓', en: '✓' },
-                  { f: 'SSO / SAML', fr: '—', pr: '—', bz: '✓', en: '✓' },
-                  { f: 'Approval workflows', fr: '—', pr: '—', bz: '✓', en: '✓' },
-                  { f: 'Webhook integrations', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { f: 'Collaborators', fr: '✕', pr: 'Up to 75', bz: 'Up to 200', en: 'Unlimited' },
+                  { f: 'Per-team permissions', fr: '✕', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Advanced roles', fr: '✕', pr: '✕', bz: '✓', en: '✓' },
+                  { f: 'SSO / SAML', fr: '✕', pr: '✕', bz: '✓', en: '✓' },
+                  { f: 'Approval workflows', fr: '✕', pr: '✕', bz: '✓', en: '✓' },
+                  { f: 'Webhook integrations', fr: '✕', pr: '✕', bz: '✓', en: '✓' },
                   { g: 'Security & Compliance', sub: 'Audit logs, certifications, and data governance' },
-                  { f: 'Activity log', fr: '—', pr: '✓', bz: '✓', en: '✓' },
-                  { f: 'Audit log retention', fr: '—', pr: '30 days', bz: '90 days', en: 'Custom' },
-                  { f: 'Uptime SLA', fr: '—', pr: '—', bz: '99.9%', en: '99.99%' },
-                  { f: 'SOC 2 compliance', fr: '—', pr: '—', bz: '—', en: '✓' },
-                  { f: 'DPA', fr: '—', pr: '—', bz: '—', en: '✓' },
+                  { f: 'Activity log', fr: '✕', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Audit log retention', fr: '✕', pr: '30 days', bz: '90 days', en: 'Custom' },
+                  { f: 'Uptime SLA', fr: '✕', pr: '✕', bz: '99.9%', en: '99.99%' },
+                  { f: 'SOC 2 compliance', fr: '✕', pr: '✕', bz: '✕', en: '✓' },
+                  { f: 'DPA', fr: '✕', pr: '✕', bz: '✕', en: '✓' },
                   { g: 'Support', sub: 'Help when you need it' },
-                  { f: 'Community support', fr: '✓', pr: '—', bz: '—', en: '—' },
-                  { f: 'Email support', fr: '—', pr: '✓', bz: '✓', en: '✓' },
-                  { f: 'Priority support', fr: '—', pr: '—', bz: '✓', en: '✓' },
-                  { f: 'Dedicated CSM', fr: '—', pr: '—', bz: '—', en: '✓' },
+                  { f: 'Community support', fr: '✓', pr: '✕', bz: '✕', en: '✕' },
+                  { f: 'Email support', fr: '✕', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Priority support', fr: '✕', pr: '✕', bz: '✓', en: '✓' },
+                  { f: 'Dedicated CSM', fr: '✕', pr: '✕', bz: '✕', en: '✓' },
                 ] as Array<{
                   g?: string;
                   sub?: string;
@@ -1454,8 +1454,8 @@ function PricingPage() {
                   const color =
                     val === '✓'
                       ? 'var(--foreground)'
-                      : val === '—'
-                        ? 'var(--input)'
+                      : val === '✕'
+                        ? 'var(--muted-foreground)'
                         : val === 'Limited'
                           ? 'var(--muted-foreground)'
                           : val === 'Custom' || val === 'Unlimited'
@@ -1470,11 +1470,11 @@ function PricingPage() {
                         textAlign: 'center',
                         color,
                         minHeight: 60,
-                        fontSize: val === '✓' || val === '—' ? 15 : 13,
+                        fontSize: val === '✓' ? 15 : 13,
                         fontWeight: val === 'Limited' || val === 'Custom' ? 600 : 400,
                       }}
                     >
-                      {val}
+                      {val === '✕' ? <XIcon size={14} strokeWidth={2.5} style={{ display: 'inline-block' }} /> : val}
                     </td>
                   );
                 };
@@ -1514,7 +1514,7 @@ function PricingPage() {
             display: 'none',
             borderRadius: 16,
             border: '1px solid rgba(255,255,255,0.1)',
-            background: '#0d0d0d',
+            background: 'transparent',
             overflow: 'hidden',
           }}
         >
@@ -1560,33 +1560,33 @@ function PricingPage() {
                   { f: 'Cloud integrations', fr: '1', pr: 'All', bz: 'All', en: 'All' },
                   { f: 'Bundler plugins (15)', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'BYOC', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
-                  { f: 'Instant rollbacks', fr: '—', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Instant rollbacks', fr: '✕', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Tag / branch env', fr: '✓', pr: '✓', bz: '✓', en: '✓' },
                   { f: 'Version history', fr: 'Limited', pr: '✓', bz: '✓', en: 'Custom' },
                   { g: 'Module Federation Native', sub: 'Built for MF teams, not bolted on', mfg: true },
-                  { f: 'Environment Overrides', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
-                  { f: 'Env Variables (no redeploy)', fr: '—', pr: '✓', bz: '✓', en: '✓' },
-                  { f: 'Zephyr DevTools', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
-                  { f: 'UML architecture map', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
-                  { f: 'zephyr.dependencies', fr: '—', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'Environment Overrides', fr: '✕', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'Env Variables (no redeploy)', fr: '✕', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Zephyr DevTools', fr: '✕', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'UML architecture map', fr: '✕', pr: '✓', bz: '✓', en: '✓', mf: true },
+                  { f: 'zephyr.dependencies', fr: '✕', pr: '✓', bz: '✓', en: '✓', mf: true },
                   { g: 'Teams & Access', sub: 'Roles, seat management, and permissions' },
-                  { f: 'Collaborators', fr: '—', pr: 'Up to 75', bz: 'Up to 200', en: 'Unlimited' },
-                  { f: 'Per-team permissions', fr: '—', pr: '✓', bz: '✓', en: '✓' },
-                  { f: 'Advanced roles', fr: '—', pr: '—', bz: '✓', en: '✓' },
-                  { f: 'SSO / SAML', fr: '—', pr: '—', bz: '✓', en: '✓' },
-                  { f: 'Approval workflows', fr: '—', pr: '—', bz: '✓', en: '✓' },
-                  { f: 'Webhook integrations', fr: '—', pr: '—', bz: '✓', en: '✓' },
+                  { f: 'Collaborators', fr: '✕', pr: 'Up to 75', bz: 'Up to 200', en: 'Unlimited' },
+                  { f: 'Per-team permissions', fr: '✕', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Advanced roles', fr: '✕', pr: '✕', bz: '✓', en: '✓' },
+                  { f: 'SSO / SAML', fr: '✕', pr: '✕', bz: '✓', en: '✓' },
+                  { f: 'Approval workflows', fr: '✕', pr: '✕', bz: '✓', en: '✓' },
+                  { f: 'Webhook integrations', fr: '✕', pr: '✕', bz: '✓', en: '✓' },
                   { g: 'Security & Compliance', sub: 'Audit logs, certifications, and data governance' },
-                  { f: 'Activity log', fr: '—', pr: '✓', bz: '✓', en: '✓' },
-                  { f: 'Audit log retention', fr: '—', pr: '30 days', bz: '90 days', en: 'Custom' },
-                  { f: 'Uptime SLA', fr: '—', pr: '—', bz: '99.9%', en: '99.99%' },
-                  { f: 'SOC 2 compliance', fr: '—', pr: '—', bz: '—', en: '✓' },
-                  { f: 'DPA', fr: '—', pr: '—', bz: '—', en: '✓' },
+                  { f: 'Activity log', fr: '✕', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Audit log retention', fr: '✕', pr: '30 days', bz: '90 days', en: 'Custom' },
+                  { f: 'Uptime SLA', fr: '✕', pr: '✕', bz: '99.9%', en: '99.99%' },
+                  { f: 'SOC 2 compliance', fr: '✕', pr: '✕', bz: '✕', en: '✓' },
+                  { f: 'DPA', fr: '✕', pr: '✕', bz: '✕', en: '✓' },
                   { g: 'Support', sub: 'Help when you need it' },
-                  { f: 'Community support', fr: '✓', pr: '—', bz: '—', en: '—' },
-                  { f: 'Email support', fr: '—', pr: '✓', bz: '✓', en: '✓' },
-                  { f: 'Priority support', fr: '—', pr: '—', bz: '✓', en: '✓' },
-                  { f: 'Dedicated CSM', fr: '—', pr: '—', bz: '—', en: '✓' },
+                  { f: 'Community support', fr: '✓', pr: '✕', bz: '✕', en: '✕' },
+                  { f: 'Email support', fr: '✕', pr: '✓', bz: '✓', en: '✓' },
+                  { f: 'Priority support', fr: '✕', pr: '✕', bz: '✓', en: '✓' },
+                  { f: 'Dedicated CSM', fr: '✕', pr: '✕', bz: '✕', en: '✓' },
                 ] as Array<{
                   g?: string;
                   sub?: string;
@@ -1635,8 +1635,8 @@ function PricingPage() {
                 const color =
                   val === '✓'
                     ? 'var(--foreground)'
-                    : val === '—'
-                      ? 'var(--input)'
+                    : val === '✕'
+                      ? 'var(--muted-foreground)'
                       : val === 'Limited'
                         ? 'var(--muted-foreground)'
                         : val === 'Custom' || val === 'Unlimited'
@@ -1667,11 +1667,11 @@ function PricingPage() {
                         borderLeft: '1px solid rgba(255,255,255,0.1)',
                         textAlign: 'center',
                         color,
-                        fontSize: val === '✓' || val === '—' ? 15 : 12,
+                        fontSize: val === '✓' ? 15 : 12,
                         fontWeight: val === 'Limited' || val === 'Custom' ? 600 : 400,
                       }}
                     >
-                      {val}
+                      {val === '✕' ? <XIcon size={14} strokeWidth={2.5} style={{ display: 'inline-block' }} /> : val}
                     </td>
                   </tr>
                 );
@@ -1730,7 +1730,7 @@ function PricingPage() {
               overflowX: 'auto',
               borderRadius: 16,
               border: '1px solid rgba(255,255,255,0.1)',
-              background: '#0d0d0d',
+              background: 'transparent',
               boxShadow: '0 20px 60px rgba(0,0,0,0.28)',
             }}
           >
@@ -1769,8 +1769,8 @@ function PricingPage() {
                 ].map((row, i) => {
                   const cell = (val = '') => {
                     const color =
-                      val === '—'
-                        ? 'var(--input)'
+                      val === '✕'
+                        ? 'var(--muted-foreground)'
                         : val === 'Custom'
                           ? 'var(--primary-muted)'
                           : 'var(--muted-foreground)';
@@ -1782,7 +1782,7 @@ function PricingPage() {
                           borderLeft: '1px solid rgba(255,255,255,0.1)',
                           textAlign: 'center',
                           color,
-                          fontSize: val === '—' ? 15 : 13,
+                          fontSize: 13,
                           fontWeight: val === 'Custom' ? 600 : 400,
                         }}
                       >
@@ -1821,7 +1821,7 @@ function PricingPage() {
               display: 'none',
               borderRadius: 16,
               border: '1px solid rgba(255,255,255,0.1)',
-              background: '#0d0d0d',
+              background: 'transparent',
               overflow: 'hidden',
             }}
           >
@@ -1852,8 +1852,8 @@ function PricingPage() {
                 ].map((row, i) => {
                   const val = (row as Record<string, string>)[mobilePlan] ?? '';
                   const color =
-                    val === '—'
-                      ? 'var(--input)'
+                    val === '✕'
+                      ? 'var(--muted-foreground)'
                       : val === 'Custom'
                         ? 'var(--primary-muted)'
                         : 'var(--muted-foreground)';
@@ -1877,7 +1877,7 @@ function PricingPage() {
                           borderLeft: '1px solid rgba(255,255,255,0.1)',
                           textAlign: 'center',
                           color,
-                          fontSize: val === '—' ? 15 : 12,
+                          fontSize: 12,
                           fontWeight: val === 'Custom' ? 600 : 400,
                         }}
                       >
@@ -1928,7 +1928,7 @@ function PricingPage() {
             style={{
               position: 'relative',
               overflow: 'hidden',
-              background: '#0d0d0d',
+              background: 'var(--card)',
               borderRadius: 16,
               padding: '56px 48px',
               display: 'flex',


### PR DESCRIPTION
## 🎫 Ticket
N/A

## 🧠 Why
Pricing page redesign to reflect the new volume-tiered pricing model.

Our previous pricing model created a hard cliff between Business ($99/seat, 20-seat cap, ~$24k/yr) and Enterprise (custom, $100k+) with no viable path for teams in between. Companies needing 25–75 seats — had to either overpay for Enterprise or cap their team size to stay on Business. The new volume-tiered Pro model eliminates that cliff entirely: pricing starts at $39/seat for small teams and scales down to $24/seat as the team grows, so the per-seat cost actually decreases with adoption. This rewards growth rather than penalizing it, creates a natural upgrade path from free to Pro to Enterprise, and keeps mid-market teams — our highest-converting segment — from stalling at the checkout decision.   

## 📝 What changed
- Complete rewrite of `/pricing` page with inline styles matching the HTML design system (`--black: #0A0A0F`, `--purple: #8B5CF6`, `--white: #F5F4F0`)
- Path selector: MF vs Teams splits prospect experience
- 3-tier cards: Free / Pro (starting at $39/seat) / Enterprise (Custom)
- **Pro calculator**: 4 volume bands (2–10 @ $39, 11–25 @ $32, 26–50 @ $27, 51–75 @ $24), clickable band cards snap slider to midpoint, 15% annual discount applied live
- 30-day free trial (not 14-day)
- Enterprise shows "Custom" pricing (no seat anchor)
- SOC2 compliance listed as Enterprise-only
- MF feature dimming when non-MF path selected
- Feature comparison table, FAQ accordion, ROI banner, Southern Glazer's proof quote

## 🧪 How to test
1. Visit the Zephyr preview URL generated by CI
2. Verify `/pricing` loads with black/purple design (not emerald)
3. Click path selector — MF features dim when "Teams" is selected
4. Click band cards in Pro calculator — slider snaps to midpoint
5. Toggle annual billing — price updates with 15% discount
6. Check Enterprise shows "Custom" with no dollar anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)