### PR TITLE
docs(changelog): 2026-05-12 product update

### DIFF
--- a/src/content/changelog/2026-05-12-custom-domains-cloudflare-worker-routes.mdx
+++ b/src/content/changelog/2026-05-12-custom-domains-cloudflare-worker-routes.mdx
@@ -1,0 +1,40 @@
+---
+title: 'Product Update: Custom Domains on Cloudflare Worker Routes'
+date: '2026-05-12'
+version: 'Mid May 2026 Product Update'
+summary: 'Custom DNS for environments now runs on Cloudflare Worker Routes for a more direct setup flow and cleaner teardown. Plus shorter environment and tag names, a fix for the org settings form, and integration modal polish.'
+tags: ['product', 'custom-domains', 'ui']
+category: 'feature'
+author: 'Zephyr Team'
+---
+
+## Summary
+
+Custom DNS for environments now runs on Cloudflare Worker Routes for a more direct setup flow and cleaner teardown. Plus shorter environment and tag names, a fix for the org settings form, and integration modal polish.
+
+## Custom Domains on Cloudflare Worker Routes
+
+Custom DNS for environments has migrated off Entri and onto Cloudflare Worker Routes. Setup is more direct, status reflects what's actually live, and removal cleans up the upstream resources automatically.
+
+- Connect a custom domain with a clearer setup flow
+- Non-Cloudflare environments resolve correctly during the connect step
+- Removed custom domains tear down their Worker Routes cleanly
+
+## Shorter Environment and Tag Names
+
+Environment and tag names can now be as short as 2 characters, with validation enforced consistently across the dashboard, API, and CLI. Short, conventional names like `qa` and `v1` work as expected.
+
+## Smaller Improvements
+
+- Organization settings form now preserves your values after saving
+- Default integration selection and checkbox state are correctly restored in the integration setup modal
+
+## What This Means for Teams
+
+- **Operators** of custom domains get a more direct setup flow and cleaner teardown
+- **Anyone naming environments or tags** can use shorter, conventional names
+- **Admins** no longer have to re-enter org settings after each save
+
+## Support
+
+If you encounter unexpected behavior, please contact the Zephyr team via chat or join our Discord: [discord.gg/zephyrcloud](https://discord.gg/zephyrcloud).

--- a/src/lib/changelog/loader.ts
+++ b/src/lib/changelog/loader.ts
@@ -38,6 +38,8 @@ export function mdxToChangelogEntry(mdx: MDXChangelogEntry, moduleKey?: string):
 
 // Import all changelog entries
 const changelogModules: Record<string, () => Promise<MDXChangelogEntry>> = {
+  '2026-05-12-custom-domains-cloudflare-worker-routes': () =>
+    import('@/content/changelog/2026-05-12-custom-domains-cloudflare-worker-routes.mdx') as Promise<MDXChangelogEntry>,
   '2026-05-05-faster-pages-smoother-settings': () =>
     import('@/content/changelog/2026-05-05-faster-pages-smoother-settings.mdx') as Promise<MDXChangelogEntry>,
   '2026-04-28-faster-permissions-stability-ui-polish': () =>


### PR DESCRIPTION
## Summary

Adds changelog entry for the Mid May 2026 product update.

## What changed

- New file: `src/content/changelog/2026-05-12-custom-domains-cloudflare-worker-routes.mdx`
- Registered loader entry: `src/lib/changelog/loader.ts`

Headline: custom domains migrated from Entri to Cloudflare Worker Routes. Plus shorter env/tag names (2-char min), org settings form preserves values after save, and integration modal polish.

## How to preview

Run `pnpm dev` and navigate to `/changelog/2026-05-12-custom-domains-cloudflare-worker-routes`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom DNS for environments now powered by Cloudflare Worker Routes with streamlined setup and teardown.
  * Environment and tag names shortened to 2+ characters with consistent validation.

* **Bug Fixes & Improvements**
  * Enhanced org settings form persistence.
  * Improved integration modal state restoration and polish.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZephyrCloudIO/zephyr-website/pull/218)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->