### PR TITLE
docs(changelog): June 10 2026 product update

### DIFF
--- a/src/content/changelog/2026-06-10-audit-logs-environment-scope-tag-attribution.mdx
+++ b/src/content/changelog/2026-06-10-audit-logs-environment-scope-tag-attribution.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Product Update: Environment-Scoped Audit Logs and Tag Attribution'
+date: '2026-06-10'
+version: 'Mid June 2026 Product Update'
+summary: 'Audit logs now show which environment each action occurred in, tags are attributed to who added them, and settings navigation has been restored.'
+tags: ['product', 'audit-logs', 'environments', 'tags', 'settings']
+category: 'feature'
+author: 'Zephyr Team'
+---
+
+## Summary
+
+Audit logs now show which environment each action occurred in, tags are attributed to who added them, and settings navigation has been restored.
+
+## Environment-Scoped Audit Logs
+
+The audit log now includes the environment where each action took place. You can see at a glance whether a deployment, token change, or configuration update happened in development, staging, or production — without having to cross-reference separately.
+
+- Audit log entries show the specific environment context for each event
+- Makes it easier to investigate incidents by filtering to the environment where something went wrong
+- Helps teams with multi-environment setups maintain clearer accountability
+
+## Tag Attribution
+
+When tags are added to applications or versions, the audit log now records who added them. This gives teams a clearer picture of how labels and categorizations evolve over time.
+
+- Know exactly who tagged a version or application and when
+- Useful for compliance and review workflows where label changes need to be traceable
+
+## What This Means for Teams
+
+- Teams managing multiple environments can now trace actions to their exact environment context in the audit log
+- Tag changes are now part of the audit trail, adding accountability to how your applications are labeled and categorized
+- Navigation to settings and project pages is reliably consistent again

--- a/src/lib/changelog/loader.ts
+++ b/src/lib/changelog/loader.ts
@@ -40,6 +40,8 @@ export function mdxToChangelogEntry(mdx: MDXChangelogEntry, moduleKey?: string):
 const changelogModules: Record<string, () => Promise<MDXChangelogEntry>> = {
   '2026-06-17-cloudflare-oauth-security-improvements': () =>
     import('@/content/changelog/2026-06-17-cloudflare-oauth-security-improvements.mdx') as Promise<MDXChangelogEntry>,
+  '2026-06-10-audit-logs-environment-scope-tag-attribution': () =>
+    import('@/content/changelog/2026-06-10-audit-logs-environment-scope-tag-attribution.mdx') as Promise<MDXChangelogEntry>,
   '2026-06-02-activity-environments-polish': () =>
     import('@/content/changelog/2026-06-02-activity-environments-polish.mdx') as Promise<MDXChangelogEntry>,
   '2026-05-26-redesigned-server-tokens-settings': () =>


### PR DESCRIPTION
## Summary

Adds changelog entry for the Mid June 2026 product update.

## What changed

- New file: `src/content/changelog/2026-06-10-audit-logs-environment-scope-tag-attribution.mdx`
- Registered loader entry: `src/lib/changelog/loader.ts`

## How to preview

Run `pnpm dev` and navigate to `/changelog/2026-06-10-audit-logs-environment-scope-tag-attribution`.