### PR TITLE
fix(deps): remediate Vanta SCA advisories (overdue + due ≤8d)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,9 +71,9 @@
       "esbuild"
     ],
     "overrides": {
-      "form-data": ">=4.0.4",
+      "form-data": "4.0.6",
       "axios": ">=1.15.1",
-      "qs": ">=6.14.1",
+      "qs": "6.15.2",
       "webpack": "5.105.4",
       "protobufjs": "7.6.3",
       "fast-uri": ">=3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  form-data: '>=4.0.4'
+  form-data: 4.0.6
   axios: '>=1.15.1'
-  qs: '>=6.14.1'
+  qs: 6.15.2
   webpack: 5.105.4
   protobufjs: 7.6.3
   fast-uri: '>=3.1.2'
@@ -1500,8 +1500,8 @@ packages:
       debug:
         optional: true
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -1585,8 +1585,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-from-parse5@8.0.3:
@@ -3884,7 +3884,7 @@ snapshots:
   axios@1.18.0(debug@4.4.3):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -4064,7 +4064,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -4176,12 +4176,12 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   format@0.2.2: {}
@@ -4212,7 +4212,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -4258,7 +4258,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 


### PR DESCRIPTION
## What's added in this PR?

Updated `pnpm.overrides` to remediate Vanta-tracked dependency vulnerabilities:

| Package | Change | CVEs |
|---------|--------|------|
| form-data | `>=4.0.4` → `4.0.6` | CVE-2026-12143 |
| qs | `>=6.14.1` → `6.15.2` | CVE-2026-8723 |

## What's the issue related to this PR?

Vanta SCA export — overdue + due within 8 days (2026-07-17). All affected packages are transitive dependencies.

## How to test this PR?

Run `pnpm install` — should resolve cleanly. No application code changed.

## Checklist

- [x] I have added explanation of the changes I made
- [x] UI related: this PR has been visually reviewed for both web, mobile, and tablet (N/A — deps only)