### PR TITLE
fix: prevent CI build hang from command substitution and missing token

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -55,14 +55,11 @@ jobs:
         env:
           ZE_SECRET_TOKEN: ${{ secrets.ZEPHYR_AUTH_TOKEN }}
         run: |
-          OUTPUT=$(pnpm run build)
-          echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -oE 'https://[^ ]+' | grep 'zephyr-cloud\.io' | tail -n1)
-          VERSION=$(echo "$OUTPUT" | grep -oP 'ZEPHYR\s+\K\S+(?=#)')
-          echo "Extracted Zephyr URL: $URL"
-          echo "Extracted VERSION: $VERSION"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          if [ -z "$ZE_SECRET_TOKEN" ]; then
+            echo "::error::ZE_SECRET_TOKEN is missing. The Zephyr build requires this token; without it the deploy falls back to an interactive login prompt and hangs. (Note: secrets are not available on PRs from forks.)"
+            exit 1
+          fi
+          pnpm run build
 
       - name: Run build for merged PR on main or development
         if: github.event.pull_request.merged == true &&


### PR DESCRIPTION
## Problem

`OUTPUT=$(pnpm run build)` in the *non-merged PR* build step hangs — both in CI and locally.

The step wrapped the build in **command substitution** to scrape the Zephyr deploy URL/version from stdout. Two issues:

1. **Command substitution captures stdout into a pipe (not a TTY)**, so the `zephyr-rspress-plugin`'s live output and any interactive prompts are hidden — the hang looks silent.
2. **When `ZE_SECRET_TOKEN` is missing/empty/invalid**, the Zephyr plugin's build-time auth falls back to an **interactive login prompt** and waits on stdin forever. In CI there is no stdin (and secrets aren't available on PRs from forks), so it hangs indefinitely.

## Why the capture was there / why it's safe to remove

The scraped `url` / `version` step outputs (`steps.build_non_merge.outputs.*`) are **not consumed anywhere** in the workflow. The downstream `zephyr-preview-environment-action` discovers preview URLs itself via the `zephyr-agent` SDK, so the scraping is redundant.

## Changes

- Drop the `OUTPUT=$(...)` command substitution and run `pnpm run build` directly (matches the merged-PR build step), so output streams live.
- Fail fast with a clear error when `ZE_SECRET_TOKEN` is missing, instead of hanging on an invisible interactive prompt.

## Testing

- `pnpm typecheck` — no workflow-affecting changes.
- Validated `.github/workflows/pull_request.yml` parses as valid YAML.