### PR TITLE
fix(deps): bump rand to 0.9.3 in image-converter lockfile

### DIFF
--- a/image-converter/Cargo.lock
+++ b/image-converter/Cargo.lock
@@ -1017,9 +1017,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
## What's added in this PR?

Bumps the transitive `rand` crate from `0.9.2` to `0.9.3` in `image-converter/Cargo.lock`. Lockfile-only change — no `Cargo.toml` edit, since `rand` is not a direct dependency:

```
rand v0.9.3
└── rav1e v0.8.1
    └── ravif v0.13.0
        └── image v0.25.10 (avif-native feature)
            ├── imgc
            └── webp v0.3.1
```

## What's the issue related to this PR?

Resolves [Dependabot alert #61](https://github.com/ZephyrCloudIO/zephyr-website/security/dependabot/61) — [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) (low severity): *Rand is unsound with a custom logger using `rand::rng()`*. Affects `>= 0.9.0, < 0.9.3`; first patched version is `0.9.3`.

## How to test this PR?

```bash
cd image-converter
cargo metadata --locked --format-version 1 >/dev/null   # lockfile is coherent
cargo tree -i rand --target all -e normal,build          # shows rand v0.9.3
```

Optionally build the CLI and convert an image:

```bash
# requires pkg-config for dav1d-sys: brew install pkgconf
cargo build --release
pnpm run imgc webp "src/images/blog/**/*.png" -q 100
```

Note: a local `cargo build` needs `pkg-config` installed for the `dav1d-sys` build script (pulled in by the same `avif-native` feature). That requirement is pre-existing and unrelated to this bump.

## Checklist

- [x] I have added explanation of the changes I made
- [ ] UI related: this PR has been visually reviewed for both web, mobile, and tablet
