### PR TITLE
docs(changelog): July 31 2026 product update

### DIFF
--- a/docs/changelog/2026-07-31-permissions-github-login-integration-defaults.mdx
+++ b/docs/changelog/2026-07-31-permissions-github-login-integration-defaults.mdx
@@ -1,0 +1,71 @@
+---
+title: 'Product Update: Permissions Reliability, GitHub Login Fixes, and Integration Defaults | Zephyr Cloud'
+description: 'This release fixes permissions for newly created organizations, improves GitHub login reliability, and tightens up integration defaults.'
+head:
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:title
+      content: 'Product Update: Permissions Reliability, GitHub Login Fixes, and Integration Defaults'
+  - - meta
+    - property: og:description
+      content: 'This release fixes permissions for newly created organizations, improves GitHub login reliability, and tightens up integration defaults.'
+  - - meta
+    - property: og:url
+      content: 'https://zephyr-cloud.io/changelog/2026-07-31-permissions-github-login-integration-defaults'
+  - - meta
+    - property: og:image
+      content: 'https://zephyr-cloud.io/images/og/default-1200x630.png'
+  - - meta
+    - property: og:image:type
+      content: 'image/png'
+  - - meta
+    - property: og:image:width
+      content: '1200'
+  - - meta
+    - property: og:image:height
+      content: '630'
+  - - meta
+    - property: og:image:secure_url
+      content: 'https://zephyr-cloud.io/images/og/default-1200x630.png'
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - meta
+    - name: twitter:title
+      content: 'Product Update: Permissions Reliability, GitHub Login Fixes, and Integration Defaults'
+  - - meta
+    - name: twitter:description
+      content: 'This release fixes permissions for newly created organizations, improves GitHub login reliability, and tightens up integration defaults.'
+  - - meta
+    - name: twitter:image
+      content: 'https://zephyr-cloud.io/images/og/default-1200x630.png'
+  - - meta
+    - name: twitter:image:type
+      content: 'image/png'
+  - - meta
+    - name: twitter:image:src
+      content: 'https://zephyr-cloud.io/images/og/default-1200x630.png'
+  - - link
+    - rel: canonical
+      href: 'https://zephyr-cloud.io/changelog/2026-07-31-permissions-github-login-integration-defaults'
+---
+
+import EntryBody from '@/content/changelog/2026-07-31-permissions-github-login-integration-defaults.mdx';
+import { ChangelogArticlePage } from '../../src/components/pages/ChangelogArticlePage';
+
+export const pageMetadata = {
+  title: 'Product Update: Permissions Reliability, GitHub Login Fixes, and Integration Defaults',
+  date: '2026-07-31',
+  version: 'Late July 2026 Product Update',
+  summary:
+    'This release fixes permissions for newly created organizations, improves GitHub login reliability, and tightens up integration defaults.',
+  tags: ['product', 'permissions', 'github', 'integrations'],
+  category: 'feature',
+  author: 'Zephyr Team',
+};
+
+<ChangelogArticlePage slug={'2026-07-31-permissions-github-login-integration-defaults'} metadata={pageMetadata}>
+  <EntryBody />
+</ChangelogArticlePage>

--- a/src/content/changelog/2026-07-31-permissions-github-login-integration-defaults.mdx
+++ b/src/content/changelog/2026-07-31-permissions-github-login-integration-defaults.mdx
@@ -1,0 +1,37 @@
+---
+title: 'Product Update: Permissions Reliability, GitHub Login Fixes, and Integration Defaults'
+date: '2026-07-31'
+version: 'Late July 2026 Product Update'
+summary: 'This release fixes permissions for newly created organizations, improves GitHub login reliability, and tightens up integration defaults.'
+tags: ['product', 'permissions', 'github', 'integrations']
+category: 'feature'
+author: 'Zephyr Team'
+---
+
+## Summary
+
+This release fixes permissions for newly created organizations, improves GitHub login reliability, and tightens up integration defaults.
+
+## Permissions Work Correctly for New Organizations
+
+When a new organization was created, members could encounter incorrect access states until a session refresh. This has been resolved — permissions are now evaluated correctly from the moment an organization is created.
+
+- New organization members see accurate access immediately.
+- No workarounds or session refreshes needed to get the correct permissions applied.
+
+## GitHub Login Now Captures Username and Email
+
+When signing in with GitHub, your username and email are now correctly linked to your Zephyr account. Previously, this information could be missing, which affected profile data and team attribution.
+
+- GitHub-authenticated users will have complete profile information going forward.
+- Teams using GitHub SSO will see accurate member details in their organization.
+
+## Smaller Improvements
+
+- New integrations now default to non-default, preventing unintended changes to your primary integration configuration.
+
+## What This Means for Teams
+
+- New organizations get correct permissions immediately — no extra steps needed after setup.
+- GitHub-authenticated team members will have accurate profile data linked to their accounts.
+- Integration setup is safer by default, with less risk of accidentally overriding an existing default.

--- a/src/generated/changelog-metadata.ts
+++ b/src/generated/changelog-metadata.ts
@@ -398,4 +398,17 @@ export const changelogMetadataEntries = [
       author: 'Zephyr Team',
     },
   },
+  {
+    slug: '2026-07-31-permissions-github-login-integration-defaults',
+    metadata: {
+      title: 'Product Update: Permissions Reliability, GitHub Login Fixes, and Integration Defaults',
+      date: '2026-07-31',
+      version: 'Late July 2026 Product Update',
+      summary:
+        'This release fixes permissions for newly created organizations, improves GitHub login reliability, and tightens up integration defaults.',
+      tags: ['product', 'permissions', 'github', 'integrations'],
+      category: 'feature',
+      author: 'Zephyr Team',
+    },
+  },
 ] as const;


### PR DESCRIPTION
## Summary

Adds changelog entry for the Late July 2026 product update (v3.3.13 → v3.3.14).

## What changed

- New file: `src/content/changelog/2026-07-31-permissions-github-login-integration-defaults.mdx`
- Registered loader entry: `src/lib/changelog/loader.ts`

## How to preview

Run `pnpm dev` and navigate to `/changelog/2026-07-31-permissions-github-login-integration-defaults`.