### PR TITLE
feat: add Product Hunt badge to homepage

### DIFF
--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -157,19 +157,24 @@ export const HeroSection: React.FC = () => {
           </div>
         </div>
 
-        <a
-          className="mt-8 inline-flex"
-          href="https://www.producthunt.com/products/the-ai-platform?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-the-ai-platform"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <img
-            alt="The AI Platform - Maximizing Human Potential | Product Hunt"
-            width="250"
-            height="54"
-            src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1222188&theme=dark&t=1786968625141"
-          />
-        </a>
+        <div className="mt-8 flex flex-col items-center gap-3">
+          <p className="text-sm text-neutral-400">
+            Check out our new product, <span className="font-medium text-white">The AI Platform</span>
+          </p>
+          <a
+            className="inline-flex"
+            href="https://www.producthunt.com/products/the-ai-platform?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-the-ai-platform"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img
+              alt="The AI Platform - Maximizing Human Potential | Product Hunt"
+              width="250"
+              height="54"
+              src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1222188&theme=dark&t=1786968625141"
+            />
+          </a>
+        </div>
       </div>
     </section>
   );

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -156,6 +156,20 @@ export const HeroSection: React.FC = () => {
             </svg>
           </div>
         </div>
+
+        <a
+          className="mt-8 inline-flex"
+          href="https://www.producthunt.com/products/the-ai-platform?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-the-ai-platform"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            alt="The AI Platform - Maximizing Human Potential | Product Hunt"
+            width="250"
+            height="54"
+            src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1222188&theme=dark&t=1786968625141"
+          />
+        </a>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

- introduce The AI Platform as Zephyr's new product below the homepage hero command
- place the Product Hunt badge directly beneath that context
- use Product Hunt's dark badge variant to match the Zephyr site theme
- preserve the supplied campaign URL, accessible alt text, dimensions, and safe external-link attributes

## Verification

- `pnpm exec prettier --check src/components/sections/HeroSection.tsx`
- `pnpm typecheck`
- `pnpm build`
- generated HTML contains the campaign link and dark badge asset
- Product Hunt SVG endpoint returns `200 image/svg+xml`

Preview: https://nestor-lopez-34563-zephyr-landing-zephyr-website--e933ca921-ze.zephyr-cloud.io
